### PR TITLE
Add theme cubit and cached preferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Awake
 
 A alarm clock app using flutter
+
+## Features
+
+- Switch between light, dark and system themes from the Settings page.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,28 +5,43 @@ import 'package:awake/services/alarm_cubit.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import 'services/shared_prefs_with_cache.dart';
+import 'services/theme_cubit.dart';
+
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-
+  await SharedPreferencesWithCache.initialize();
+  final index =
+      SharedPreferencesWithCache.instance.get<int>('themeMode') ??
+          ThemeMode.system.index;
   await Alarm.init();
 
-  runApp(const MyApp());
+  final themeCubit = ThemeCubit(ThemeMode.values[index]);
+  runApp(MyApp(themeCubit: themeCubit));
 }
-
 class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+  const MyApp({super.key, required this.themeCubit});
+
+  final ThemeCubit themeCubit;
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider(
-      create: (_) => AlarmCubit(),
-      child: MaterialApp(
-        debugShowCheckedModeBanner: false,
-        title: 'Awake- The Alarm Clock',
-        themeMode: ThemeMode.system,
-        theme: AppTheme.lightTheme,
-        darkTheme: AppTheme.darkTheme,
-        home: const Home(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider(create: (_) => AlarmCubit()),
+        BlocProvider<ThemeCubit>.value(value: themeCubit),
+      ],
+      child: BlocBuilder<ThemeCubit, ThemeMode>(
+        builder: (context, mode) {
+          return MaterialApp(
+            debugShowCheckedModeBanner: false,
+            title: 'Awake- The Alarm Clock',
+            themeMode: mode,
+            theme: AppTheme.lightTheme,
+            darkTheme: AppTheme.darkTheme,
+            home: const Home(),
+          );
+        },
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -11,25 +11,20 @@ import 'services/theme_cubit.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await SharedPreferencesWithCache.initialize();
-  final index =
-      SharedPreferencesWithCache.instance.get<int>('themeMode') ??
-          ThemeMode.system.index;
   await Alarm.init();
 
-  final themeCubit = ThemeCubit(ThemeMode.values[index]);
-  runApp(MyApp(themeCubit: themeCubit));
+  runApp(MyApp());
 }
-class MyApp extends StatelessWidget {
-  const MyApp({super.key, required this.themeCubit});
 
-  final ThemeCubit themeCubit;
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
 
   @override
   Widget build(BuildContext context) {
     return MultiBlocProvider(
       providers: [
         BlocProvider(create: (_) => AlarmCubit()),
-        BlocProvider<ThemeCubit>.value(value: themeCubit),
+        BlocProvider(create: (_) => ThemeCubit()),
       ],
       child: BlocBuilder<ThemeCubit, ThemeMode>(
         builder: (context, mode) {

--- a/lib/screens/alarm_ringing_screen.dart
+++ b/lib/screens/alarm_ringing_screen.dart
@@ -13,8 +13,7 @@ class AlarmRingingScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark =
-        MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
     return Scaffold(
       body: DecoratedBox(
         decoration: BoxDecoration(

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -64,8 +64,7 @@ class _HomeState extends State<Home> {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark =
-        MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
 
     return Scaffold(
       floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
@@ -247,8 +246,7 @@ class _HomeState extends State<Home> {
                                     onPressed: () {
                                       Navigator.of(context).push(
                                         MaterialPageRoute(
-                                          builder:
-                                              (context) => SettingsScreen(),
+                                          builder: (context) => const SettingsScreen(),
                                         ),
                                       );
                                     },

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,29 +1,30 @@
 import 'package:awake/theme/app_colors.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../services/theme_cubit.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark =
-        MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
     return Scaffold(
-      backgroundColor: (isDark) ? AppColors.darkBorder : Colors.white,
+      backgroundColor: isDark ? AppColors.darkBorder : Colors.white,
       body: Hero(
-        tag: "InnerDecoratedBox",
+        tag: 'InnerDecoratedBox',
         child: DecoratedBox(
           decoration: BoxDecoration(
             border: Border.all(
-              color: (isDark) ? AppColors.darkBorder : Colors.white,
+              color: isDark ? AppColors.darkBorder : Colors.white,
             ),
             gradient: LinearGradient(
               begin: Alignment.topCenter,
               end: Alignment.bottomCenter,
-              colors:
-                  (isDark)
-                      ? [AppColors.darkScaffold1, AppColors.darkScaffold2]
-                      : [AppColors.lightContainer1, AppColors.lightContainer2],
+              colors: isDark
+                  ? [AppColors.darkScaffold1, AppColors.darkScaffold2]
+                  : [AppColors.lightContainer1, AppColors.lightContainer2],
             ),
           ),
           child: SafeArea(
@@ -36,30 +37,57 @@ class SettingsScreen extends StatelessWidget {
                     IconButton(
                       onPressed: () => Navigator.pop(context),
                       style: IconButton.styleFrom(
-                        foregroundColor:
-                            (isDark)
-                                ? AppColors.darkBackgroundText
-                                : AppColors.lightBackgroundText,
+                        foregroundColor: isDark
+                            ? AppColors.darkBackgroundText
+                            : AppColors.lightBackgroundText,
                       ),
-                      icon: Icon(Icons.arrow_back),
+                      icon: const Icon(Icons.arrow_back),
                     ),
                     Text(
-                      "Settings",
+                      'Settings',
                       style: TextStyle(
-                        color:
-                            (isDark)
-                                ? AppColors.darkBackgroundText
-                                : AppColors.lightBackgroundText,
+                        color: isDark
+                            ? AppColors.darkBackgroundText
+                            : AppColors.lightBackgroundText,
                         fontFamily: 'Poppins',
                         fontSize: 18,
                         fontWeight: FontWeight.w500,
                         letterSpacing: 0.03,
                       ),
                     ),
-                    IconButton(onPressed: null, icon: Offstage()),
+                    const IconButton(onPressed: null, icon: Offstage()),
                   ],
                 ),
-                // Add your settings options here
+                const SizedBox(height: 20),
+                BlocBuilder<ThemeCubit, ThemeMode>(
+                  builder: (context, mode) {
+                    return Column(
+                      children: [
+                        RadioListTile<ThemeMode>(
+                          title: const Text('System Default'),
+                          value: ThemeMode.system,
+                          groupValue: mode,
+                          onChanged: (m) =>
+                              context.read<ThemeCubit>().setTheme(m!),
+                        ),
+                        RadioListTile<ThemeMode>(
+                          title: const Text('Light'),
+                          value: ThemeMode.light,
+                          groupValue: mode,
+                          onChanged: (m) =>
+                              context.read<ThemeCubit>().setTheme(m!),
+                        ),
+                        RadioListTile<ThemeMode>(
+                          title: const Text('Dark'),
+                          value: ThemeMode.dark,
+                          groupValue: mode,
+                          onChanged: (m) =>
+                              context.read<ThemeCubit>().setTheme(m!),
+                        ),
+                      ],
+                    );
+                  },
+                ),
               ],
             ),
           ),

--- a/lib/services/shared_prefs_with_cache.dart
+++ b/lib/services/shared_prefs_with_cache.dart
@@ -1,0 +1,36 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SharedPreferencesWithCache {
+  SharedPreferencesWithCache._(this._prefs);
+
+  static SharedPreferencesWithCache? _instance;
+  final SharedPreferences _prefs;
+  final Map<String, Object?> _cache = {};
+
+  static Future<void> initialize() async {
+    final prefs = await SharedPreferences.getInstance();
+    _instance = SharedPreferencesWithCache._(prefs);
+  }
+
+  static SharedPreferencesWithCache get instance {
+    final inst = _instance;
+    if (inst == null) {
+      throw Exception('SharedPreferencesWithCache not initialized');
+    }
+    return inst;
+  }
+
+  T? get<T>(String key) {
+    if (_cache.containsKey(key)) {
+      return _cache[key] as T?;
+    }
+    final value = _prefs.get(key);
+    _cache[key] = value;
+    return value as T?;
+  }
+
+  Future<bool> setInt(String key, int value) async {
+    _cache[key] = value;
+    return _prefs.setInt(key, value);
+  }
+}

--- a/lib/services/theme_cubit.dart
+++ b/lib/services/theme_cubit.dart
@@ -4,7 +4,13 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'shared_prefs_with_cache.dart';
 
 class ThemeCubit extends Cubit<ThemeMode> {
-  ThemeCubit(ThemeMode initialMode) : super(initialMode);
+  ThemeCubit()
+    : super(
+        ThemeMode.values[SharedPreferencesWithCache.instance.get<int>(
+              'themeMode',
+            ) ??
+            ThemeMode.system.index],
+      );
 
   Future<void> setTheme(ThemeMode mode) async {
     await SharedPreferencesWithCache.instance.setInt('themeMode', mode.index);

--- a/lib/services/theme_cubit.dart
+++ b/lib/services/theme_cubit.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import 'shared_prefs_with_cache.dart';
+
+class ThemeCubit extends Cubit<ThemeMode> {
+  ThemeCubit(ThemeMode initialMode) : super(initialMode);
+
+  Future<void> setTheme(ThemeMode mode) async {
+    await SharedPreferencesWithCache.instance.setInt('themeMode', mode.index);
+    emit(mode);
+  }
+}

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -5,6 +5,7 @@ class AppTheme {
   AppTheme._();
 
   static ThemeData get lightTheme => ThemeData(
+    brightness: Brightness.light,
     colorSchemeSeed: AppColors.primary,
     dialogTheme: const DialogThemeData(
       backgroundColor: AppColors.lightScaffold1,
@@ -23,6 +24,7 @@ class AppTheme {
   );
 
   static ThemeData get darkTheme => ThemeData(
+    brightness: Brightness.dark,
     colorSchemeSeed: AppColors.primaryAlt,
     dialogTheme: const DialogThemeData(
       backgroundColor: AppColors.darkScaffold1,

--- a/lib/widgets/add_button.dart
+++ b/lib/widgets/add_button.dart
@@ -7,8 +7,7 @@ class AddButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark =
-        MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
     return DecoratedBox(
       decoration: BoxDecoration(
         gradient: LinearGradient(

--- a/lib/widgets/alarm_tile.dart
+++ b/lib/widgets/alarm_tile.dart
@@ -44,8 +44,7 @@ class AlarmTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark =
-        MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
     return Container(
       padding: const EdgeInsets.all(1),
       margin: const EdgeInsets.only(top: 23),

--- a/lib/widgets/clock.dart
+++ b/lib/widgets/clock.dart
@@ -21,8 +21,7 @@ class _ClockWidgetState extends State<ClockWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark =
-        MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
     return CustomPaint(
       size: Size.infinite,
       willChange: true,

--- a/lib/widgets/gradient_switch.dart
+++ b/lib/widgets/gradient_switch.dart
@@ -21,8 +21,7 @@ class _GradientSwitchState extends State<GradientSwitch> {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark =
-        MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
     return GestureDetector(
       onTap: () {
         setState(() {

--- a/lib/widgets/minus_button.dart
+++ b/lib/widgets/minus_button.dart
@@ -7,8 +7,7 @@ class MinusButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark =
-        MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
 
     return DecoratedBox(
       decoration: BoxDecoration(

--- a/lib/widgets/snooze_button.dart
+++ b/lib/widgets/snooze_button.dart
@@ -27,8 +27,7 @@ class _SnoozeButtonState extends State<SnoozeButton> {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark =
-        MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
 
     return Row(
       children: [

--- a/lib/widgets/stop_alarm.dart
+++ b/lib/widgets/stop_alarm.dart
@@ -7,8 +7,7 @@ class StopButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark =
-        MediaQuery.platformBrightnessOf(context) == Brightness.dark;
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
     return DecoratedBox(
       decoration: BoxDecoration(
         gradient: LinearGradient(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -377,7 +377,7 @@ packages:
     source: hosted
     version: "0.28.0"
   shared_preferences:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: shared_preferences
       sha256: "6e8bf70b7fef813df4e9a36f658ac46d107db4b4cfe1048b477d4e453a8159f5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   flutter_inset_box_shadow_update: ^0.0.1
   lottie: ^3.3.1
   permission_handler: ^12.0.1
-  shared_preferences: ^2.2.2
+  shared_preferences: ^2.5.3
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   flutter_inset_box_shadow_update: ^0.0.1
   lottie: ^3.3.1
   permission_handler: ^12.0.1
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- create `SharedPreferencesWithCache` utility
- manage theme selection with `ThemeCubit`
- initialize cached preferences and theme cubit in `main.dart`
- refactor Home and Settings screens to use Bloc-based theme updates

## Testing
- `dart pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68688357ab388324833eb4371e68f4f1