### PR TITLE
Replace theme radios with list tile

### DIFF
--- a/lib/extensions/context_extensions.dart
+++ b/lib/extensions/context_extensions.dart
@@ -1,0 +1,5 @@
+import 'package:flutter/material.dart';
+
+extension ThemeModeContext on BuildContext {
+  bool get isDarkMode => Theme.of(this).brightness == Brightness.dark;
+}

--- a/lib/screens/alarm_ringing_screen.dart
+++ b/lib/screens/alarm_ringing_screen.dart
@@ -1,11 +1,11 @@
 import 'package:alarm/alarm.dart';
+import 'package:awake/extensions/context_extensions.dart';
 import 'package:awake/theme/app_colors.dart';
 import 'package:awake/services/alarm_cubit.dart';
 import 'package:awake/widgets/snooze_button.dart';
 import 'package:awake/widgets/stop_alarm.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import '../extensions/context_extensions.dart';
 import 'package:lottie/lottie.dart';
 
 class AlarmRingingScreen extends StatelessWidget {

--- a/lib/screens/alarm_ringing_screen.dart
+++ b/lib/screens/alarm_ringing_screen.dart
@@ -5,6 +5,7 @@ import 'package:awake/widgets/snooze_button.dart';
 import 'package:awake/widgets/stop_alarm.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import '../extensions/context_extensions.dart';
 import 'package:lottie/lottie.dart';
 
 class AlarmRingingScreen extends StatelessWidget {
@@ -13,7 +14,7 @@ class AlarmRingingScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final bool isDark = context.isDarkMode;
     return Scaffold(
       body: DecoratedBox(
         decoration: BoxDecoration(

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -13,6 +13,7 @@ import 'package:awake/widgets/alarm_tile.dart';
 import 'package:awake/widgets/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import '../extensions/context_extensions.dart';
 
 class Home extends StatefulWidget {
   const Home({super.key});
@@ -64,7 +65,7 @@ class _HomeState extends State<Home> {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final bool isDark = context.isDarkMode;
 
     return Scaffold(
       floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:math';
 import 'package:alarm/alarm.dart';
 import 'package:alarm/utils/alarm_set.dart';
+import 'package:awake/extensions/context_extensions.dart';
 import 'package:awake/theme/app_colors.dart';
 import 'package:awake/models/alarm_model.dart';
 import 'package:awake/screens/alarm_ringing_screen.dart';
@@ -13,7 +14,6 @@ import 'package:awake/widgets/alarm_tile.dart';
 import 'package:awake/widgets/clock.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import '../extensions/context_extensions.dart';
 
 class Home extends StatefulWidget {
   const Home({super.key});
@@ -176,110 +176,115 @@ class _HomeState extends State<Home> {
                 flex: 2,
                 child: Hero(
                   tag: "InnerDecoratedBox",
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      border: Border.all(
-                        color: (isDark) ? AppColors.darkBorder : Colors.white,
+                  child: Material(
+                    type: MaterialType.transparency,
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        border: Border.all(
+                          color: (isDark) ? AppColors.darkBorder : Colors.white,
+                        ),
+                        borderRadius: const BorderRadius.only(
+                          topLeft: Radius.circular(20),
+                          topRight: Radius.circular(20),
+                        ),
+                        gradient: LinearGradient(
+                          begin: Alignment.topCenter,
+                          end: Alignment.bottomCenter,
+                          colors:
+                              (isDark)
+                                  ? [
+                                    AppColors.darkScaffold1,
+                                    AppColors.darkScaffold2,
+                                  ]
+                                  : [
+                                    AppColors.lightContainer1,
+                                    AppColors.lightContainer2,
+                                  ],
+                        ),
                       ),
-                      borderRadius: const BorderRadius.only(
-                        topLeft: Radius.circular(20),
-                        topRight: Radius.circular(20),
-                      ),
-                      gradient: LinearGradient(
-                        begin: Alignment.topCenter,
-                        end: Alignment.bottomCenter,
-                        colors:
-                            (isDark)
-                                ? [
-                                  AppColors.darkScaffold1,
-                                  AppColors.darkScaffold2,
-                                ]
-                                : [
-                                  AppColors.lightContainer1,
-                                  AppColors.lightContainer2,
-                                ],
-                      ),
-                    ),
-                    child: BlocBuilder<AlarmCubit, List<AlarmModel>>(
-                      buildWhen: (previous, current) => previous != current,
-                      builder: (context, alarms) {
-                        if (alarms.isEmpty) {
-                          return Center(
-                            child: Text(
-                              "No Alarms Added Yet",
-                              style: TextStyle(
-                                color:
-                                    (isDark)
-                                        ? AppColors.darkBackgroundText
-                                        : AppColors.lightBackgroundText,
-                                fontFamily: 'Poppins',
-                                fontSize: 18,
-                                fontWeight: FontWeight.w500,
-                                letterSpacing: 0.03,
+                      child: BlocBuilder<AlarmCubit, List<AlarmModel>>(
+                        buildWhen: (previous, current) => previous != current,
+                        builder: (context, alarms) {
+                          if (alarms.isEmpty) {
+                            return Center(
+                              child: Text(
+                                "No Alarms Added Yet",
+                                style: TextStyle(
+                                  color:
+                                      (isDark)
+                                          ? AppColors.darkBackgroundText
+                                          : AppColors.lightBackgroundText,
+                                  fontFamily: 'Poppins',
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.w500,
+                                  letterSpacing: 0.03,
+                                ),
                               ),
-                            ),
-                          );
-                        } else {
-                          return ListView(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 20,
-                              vertical: 24,
-                            ),
-                            children: [
-                              Row(
-                                children: [
-                                  const SizedBox(width: 15),
-                                  Text(
-                                    "Alarms",
-                                    style: TextStyle(
-                                      color:
-                                          (isDark)
-                                              ? AppColors.darkBackgroundText
-                                              : AppColors.lightBackgroundText,
-                                      fontFamily: 'Poppins',
-                                      fontSize: 18,
-                                      fontWeight: FontWeight.w500,
-                                      letterSpacing: 0.03,
-                                    ),
-                                  ),
-                                  const Spacer(),
-                                  IconButton(
-                                    onPressed: () {
-                                      Navigator.of(context).push(
-                                        MaterialPageRoute(
-                                          builder: (context) => const SettingsScreen(),
-                                        ),
-                                      );
-                                    },
-                                    style: IconButton.styleFrom(
-                                      foregroundColor:
-                                          (isDark)
-                                              ? AppColors.darkBackgroundText
-                                              : AppColors.lightBackgroundText,
-                                    ),
-                                    icon: Icon(Icons.settings),
-                                  ),
-                                  const SizedBox(width: 15),
-                                ],
+                            );
+                          } else {
+                            return ListView(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 20,
+                                vertical: 24,
                               ),
-                              ...[
-                                for (
-                                  int index = 0;
-                                  index < alarms.length;
-                                  index++
-                                )
-                                  AlarmTile(
-                                    alarmModel: alarms[index],
-                                    onDelete:
-                                        () => context
-                                            .read<AlarmCubit>()
-                                            .deleteAlarmModel(alarms[index]),
-                                  ),
+                              children: [
+                                Row(
+                                  children: [
+                                    const SizedBox(width: 15),
+                                    Text(
+                                      "Alarms",
+                                      style: TextStyle(
+                                        color:
+                                            (isDark)
+                                                ? AppColors.darkBackgroundText
+                                                : AppColors.lightBackgroundText,
+                                        fontFamily: 'Poppins',
+                                        fontSize: 18,
+                                        fontWeight: FontWeight.w500,
+                                        letterSpacing: 0.03,
+                                      ),
+                                    ),
+                                    const Spacer(),
+                                    IconButton(
+                                      onPressed: () {
+                                        Navigator.of(context).push(
+                                          MaterialPageRoute(
+                                            builder:
+                                                (context) =>
+                                                    const SettingsScreen(),
+                                          ),
+                                        );
+                                      },
+                                      style: IconButton.styleFrom(
+                                        foregroundColor:
+                                            (isDark)
+                                                ? AppColors.darkBackgroundText
+                                                : AppColors.lightBackgroundText,
+                                      ),
+                                      icon: Icon(Icons.settings),
+                                    ),
+                                    const SizedBox(width: 15),
+                                  ],
+                                ),
+                                ...[
+                                  for (
+                                    int index = 0;
+                                    index < alarms.length;
+                                    index++
+                                  )
+                                    AlarmTile(
+                                      alarmModel: alarms[index],
+                                      onDelete:
+                                          () => context
+                                              .read<AlarmCubit>()
+                                              .deleteAlarmModel(alarms[index]),
+                                    ),
+                                ],
                               ],
-                            ],
-                          );
-                        }
-                      },
+                            );
+                          }
+                        },
+                      ),
                     ),
                   ),
                 ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,15 +1,17 @@
 import 'package:awake/theme/app_colors.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import '../extensions/context_extensions.dart';
 
 import '../services/theme_cubit.dart';
+import '../widgets/theme_list_tile.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final bool isDark = context.isDarkMode;
     return Scaffold(
       backgroundColor: isDark ? AppColors.darkBorder : Colors.white,
       body: Hero(
@@ -61,30 +63,10 @@ class SettingsScreen extends StatelessWidget {
                 const SizedBox(height: 20),
                 BlocBuilder<ThemeCubit, ThemeMode>(
                   builder: (context, mode) {
-                    return Column(
-                      children: [
-                        RadioListTile<ThemeMode>(
-                          title: const Text('System Default'),
-                          value: ThemeMode.system,
-                          groupValue: mode,
-                          onChanged: (m) =>
-                              context.read<ThemeCubit>().setTheme(m!),
-                        ),
-                        RadioListTile<ThemeMode>(
-                          title: const Text('Light'),
-                          value: ThemeMode.light,
-                          groupValue: mode,
-                          onChanged: (m) =>
-                              context.read<ThemeCubit>().setTheme(m!),
-                        ),
-                        RadioListTile<ThemeMode>(
-                          title: const Text('Dark'),
-                          value: ThemeMode.dark,
-                          groupValue: mode,
-                          onChanged: (m) =>
-                              context.read<ThemeCubit>().setTheme(m!),
-                        ),
-                      ],
+                    return ThemeListTile(
+                      mode: mode,
+                      onChanged: (m) =>
+                          context.read<ThemeCubit>().setTheme(m),
                     );
                   },
                 ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,10 +1,9 @@
+import 'package:awake/extensions/context_extensions.dart';
+import 'package:awake/services/theme_cubit.dart';
 import 'package:awake/theme/app_colors.dart';
+import 'package:awake/widgets/theme_list_tile.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import '../extensions/context_extensions.dart';
-
-import '../services/theme_cubit.dart';
-import '../widgets/theme_list_tile.dart';
 
 class SettingsScreen extends StatelessWidget {
   const SettingsScreen({super.key});
@@ -16,61 +15,67 @@ class SettingsScreen extends StatelessWidget {
       backgroundColor: isDark ? AppColors.darkBorder : Colors.white,
       body: Hero(
         tag: 'InnerDecoratedBox',
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            border: Border.all(
-              color: isDark ? AppColors.darkBorder : Colors.white,
+        child: Material(
+          type: MaterialType.transparency,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topCenter,
+                end: Alignment.bottomCenter,
+                colors:
+                    isDark
+                        ? [AppColors.darkScaffold1, AppColors.darkScaffold2]
+                        : [
+                          AppColors.lightContainer1,
+                          AppColors.lightContainer2,
+                        ],
+              ),
             ),
-            gradient: LinearGradient(
-              begin: Alignment.topCenter,
-              end: Alignment.bottomCenter,
-              colors: isDark
-                  ? [AppColors.darkScaffold1, AppColors.darkScaffold2]
-                  : [AppColors.lightContainer1, AppColors.lightContainer2],
-            ),
-          ),
-          child: SafeArea(
-            minimum: const EdgeInsets.symmetric(vertical: 30, horizontal: 10),
-            child: Column(
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    IconButton(
-                      onPressed: () => Navigator.pop(context),
-                      style: IconButton.styleFrom(
-                        foregroundColor: isDark
-                            ? AppColors.darkBackgroundText
-                            : AppColors.lightBackgroundText,
+            child: SafeArea(
+              minimum: const EdgeInsets.symmetric(vertical: 30, horizontal: 10),
+              child: Column(
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      IconButton(
+                        onPressed: () => Navigator.pop(context),
+                        style: IconButton.styleFrom(
+                          foregroundColor:
+                              isDark
+                                  ? AppColors.darkBackgroundText
+                                  : AppColors.lightBackgroundText,
+                        ),
+                        icon: const Icon(Icons.arrow_back),
                       ),
-                      icon: const Icon(Icons.arrow_back),
-                    ),
-                    Text(
-                      'Settings',
-                      style: TextStyle(
-                        color: isDark
-                            ? AppColors.darkBackgroundText
-                            : AppColors.lightBackgroundText,
-                        fontFamily: 'Poppins',
-                        fontSize: 18,
-                        fontWeight: FontWeight.w500,
-                        letterSpacing: 0.03,
+                      Text(
+                        'Settings',
+                        style: TextStyle(
+                          color:
+                              isDark
+                                  ? AppColors.darkBackgroundText
+                                  : AppColors.lightBackgroundText,
+                          fontFamily: 'Poppins',
+                          fontSize: 18,
+                          fontWeight: FontWeight.w500,
+                          letterSpacing: 0.03,
+                        ),
                       ),
-                    ),
-                    const IconButton(onPressed: null, icon: Offstage()),
-                  ],
-                ),
-                const SizedBox(height: 20),
-                BlocBuilder<ThemeCubit, ThemeMode>(
-                  builder: (context, mode) {
-                    return ThemeListTile(
-                      mode: mode,
-                      onChanged: (m) =>
-                          context.read<ThemeCubit>().setTheme(m),
-                    );
-                  },
-                ),
-              ],
+                      const IconButton(onPressed: null, icon: Offstage()),
+                    ],
+                  ),
+                  const SizedBox(height: 20),
+                  BlocBuilder<ThemeCubit, ThemeMode>(
+                    builder: (context, mode) {
+                      return ThemeListTile(
+                        mode: mode,
+                        onChanged:
+                            (m) => context.read<ThemeCubit>().setTheme(m),
+                      );
+                    },
+                  ),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/widgets/theme_list_tile.dart
+++ b/lib/widgets/theme_list_tile.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
+import '../extensions/context_extensions.dart';
+
+class ThemeListTile extends StatelessWidget {
+  final ThemeMode mode;
+  final ValueChanged<ThemeMode> onChanged;
+
+  const ThemeListTile({
+    super.key,
+    required this.mode,
+    required this.onChanged,
+  });
+
+  IconData _iconForMode(ThemeMode m) {
+    switch (m) {
+      case ThemeMode.light:
+        return Icons.light_mode;
+      case ThemeMode.dark:
+        return Icons.dark_mode;
+      case ThemeMode.system:
+        return Icons.phone_iphone;
+    }
+  }
+
+  ThemeMode _nextMode(ThemeMode m) {
+    switch (m) {
+      case ThemeMode.system:
+        return ThemeMode.light;
+      case ThemeMode.light:
+        return ThemeMode.dark;
+      case ThemeMode.dark:
+        return ThemeMode.system;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isDark = context.isDarkMode;
+    final color =
+        isDark ? AppColors.darkBackgroundText : AppColors.lightBackgroundText;
+    return ListTile(
+      title: Text(
+        'Theme',
+        style: TextStyle(
+          color: color,
+          fontFamily: 'Poppins',
+        ),
+      ),
+      trailing: Icon(
+        _iconForMode(mode),
+        color: color,
+      ),
+      onTap: () => onChanged(_nextMode(mode)),
+    );
+  }
+}

--- a/lib/widgets/theme_list_tile.dart
+++ b/lib/widgets/theme_list_tile.dart
@@ -1,16 +1,12 @@
+import 'package:awake/extensions/context_extensions.dart';
+import 'package:awake/theme/app_colors.dart';
 import 'package:flutter/material.dart';
-import '../theme/app_colors.dart';
-import '../extensions/context_extensions.dart';
 
 class ThemeListTile extends StatelessWidget {
   final ThemeMode mode;
   final ValueChanged<ThemeMode> onChanged;
 
-  const ThemeListTile({
-    super.key,
-    required this.mode,
-    required this.onChanged,
-  });
+  const ThemeListTile({super.key, required this.mode, required this.onChanged});
 
   IconData _iconForMode(ThemeMode m) {
     switch (m) {
@@ -42,15 +38,9 @@ class ThemeListTile extends StatelessWidget {
     return ListTile(
       title: Text(
         'Theme',
-        style: TextStyle(
-          color: color,
-          fontFamily: 'Poppins',
-        ),
+        style: TextStyle(color: color, fontFamily: 'Poppins'),
       ),
-      trailing: Icon(
-        _iconForMode(mode),
-        color: color,
-      ),
+      trailing: Icon(_iconForMode(mode), color: color),
       onTap: () => onChanged(_nextMode(mode)),
     );
   }


### PR DESCRIPTION
## Summary
- update settings UI with ThemeListTile
- add ThemeListTile widget for cycling theme modes
- add ThemeMode context extension and apply across screens

## Testing
- `dart analyze`


------
https://chatgpt.com/codex/tasks/task_e_68688c49792083248b2538b54d7dd8a3