### PR TITLE
Add expandable alarm tile with day selection

### DIFF
--- a/lib/models/alarm_db_entry.dart
+++ b/lib/models/alarm_db_entry.dart
@@ -3,14 +3,16 @@ import 'package:flutter/material.dart';
 class AlarmDbEntry {
   final TimeOfDay time;
   final List<int> days;
+  final bool enabled;
 
-  AlarmDbEntry({required this.time, required this.days});
+  AlarmDbEntry({required this.time, required this.days, this.enabled = true});
 
   Map<String, dynamic> toMap() {
     final timeString = '${time.hour}:${time.minute}';
     return {
       'time': timeString,
       'days': days.join(','),
+      'enabled': enabled ? 1 : 0,
     };
   }
 
@@ -19,12 +21,15 @@ class AlarmDbEntry {
     final hour = int.parse(parts[0]);
     final minute = int.parse(parts[1]);
     final daysString = map['days'] as String? ?? '';
-    final dayList = daysString.isEmpty
-        ? <int>[]
-        : daysString.split(',').map(int.parse).toList();
+    final dayList =
+        daysString.isEmpty
+            ? <int>[]
+            : daysString.split(',').map(int.parse).toList();
+    final enabled = (map['enabled'] as int?) ?? 1;
     return AlarmDbEntry(
       time: TimeOfDay(hour: hour, minute: minute),
       days: dayList,
+      enabled: enabled == 1,
     );
   }
 }

--- a/lib/models/alarm_model.dart
+++ b/lib/models/alarm_model.dart
@@ -4,22 +4,31 @@ import 'package:flutter/material.dart';
 
 class AlarmModel {
   final TimeOfDay timeOfDay;
+  final List<int> days;
+  final bool enabled;
   final List<AlarmSettings> alarmSettings;
 
-  AlarmModel({required this.timeOfDay, this.alarmSettings = const []});
+  AlarmModel({
+    required this.timeOfDay,
+    required this.days,
+    this.enabled = true,
+    this.alarmSettings = const [],
+  });
 
   @override
   bool operator ==(Object other) {
     return other is AlarmModel &&
         other.timeOfDay == timeOfDay &&
+        listEquals(other.days, days) &&
+        other.enabled == enabled &&
         listEquals(other.alarmSettings, alarmSettings);
   }
 
   @override
-  int get hashCode => Object.hash(timeOfDay, alarmSettings);
+  int get hashCode => Object.hash(timeOfDay, days, enabled, alarmSettings);
 
   @override
   String toString() {
-    return 'AlarmModel(timeOfDay: $timeOfDay,alarmSettings: $alarmSettings)';
+    return 'AlarmModel(timeOfDay: $timeOfDay, days: $days, enabled: $enabled, alarmSettings: $alarmSettings)';
   }
 }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -41,9 +41,11 @@ class _HomeState extends State<Home> {
   @override
   void initState() {
     super.initState();
-    unawaited(AlarmPermissions.checkNotificationPermission().then(
-      (_) => AlarmPermissions.checkAndroidScheduleExactAlarmPermission(),
-    ));
+    unawaited(
+      AlarmPermissions.checkNotificationPermission().then(
+        (_) => AlarmPermissions.checkAndroidScheduleExactAlarmPermission(),
+      ),
+    );
     _ringSubscription = Alarm.ringing.listen(_ringingAlarmsChanged);
   }
 
@@ -275,10 +277,20 @@ class _HomeState extends State<Home> {
                                   )
                                     AlarmTile(
                                       alarmModel: alarms[index],
-                                      onDelete:
-                                          () => context
+                                      onEnabledChanged:
+                                          (v) => context
                                               .read<AlarmCubit>()
-                                              .deleteAlarmModel(alarms[index]),
+                                              .toggleAlarmEnabled(
+                                                alarms[index].timeOfDay,
+                                                v,
+                                              ),
+                                      onDaysChanged:
+                                          (days) => context
+                                              .read<AlarmCubit>()
+                                              .updateAlarmDays(
+                                                alarms[index].timeOfDay,
+                                                days,
+                                              ),
                                     ),
                                 ],
                               ],

--- a/lib/services/alarm_database.dart
+++ b/lib/services/alarm_database.dart
@@ -10,11 +10,18 @@ class AlarmDatabase {
     final path = '$dir/alarms.db';
     _db = await openDatabase(
       path,
-      version: 1,
+      version: 2,
       onCreate: (db, version) async {
         await db.execute(
-          'CREATE TABLE alarms(time TEXT PRIMARY KEY, days TEXT)',
+          'CREATE TABLE alarms(time TEXT PRIMARY KEY, days TEXT, enabled INTEGER)',
         );
+      },
+      onUpgrade: (db, oldVersion, newVersion) async {
+        if (oldVersion == 1 && newVersion == 2) {
+          await db.execute(
+            'ALTER TABLE alarms ADD COLUMN enabled INTEGER DEFAULT 1',
+          );
+        }
       },
     );
   }

--- a/lib/widgets/alarm_tile.dart
+++ b/lib/widgets/alarm_tile.dart
@@ -83,30 +83,40 @@ class _AlarmTileState extends State<AlarmTile> {
               });
               widget.onDaysChanged(_selectedDays.toList());
             },
-            child: Container(
-              padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 6),
-              decoration: BoxDecoration(
-                color:
-                    _selectedDays.contains(i + 1)
-                        ? AppColors.primary
-                        : Colors.transparent,
-                borderRadius: BorderRadius.circular(6),
-                border: Border.all(
-                  color:
-                      isDark ? AppColors.darkBorder : AppColors.lightBlueGrey,
-                ),
-              ),
-              child: Text(
-                dayLabels[i],
-                style: TextStyle(
-                  fontFamily: 'Poppins',
-                  fontSize: 12,
+            child: SizedBox(
+              height: 24,
+              width: 24,
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
                   color:
                       _selectedDays.contains(i + 1)
-                          ? Colors.white
-                          : isDark
-                          ? AppColors.darkBackgroundText
-                          : AppColors.lightBackgroundText,
+                          ? AppColors.primary
+                          : Colors.transparent,
+                  border:
+                      _selectedDays.contains(i + 1)
+                          ? null
+                          : Border.all(
+                            color:
+                                isDark
+                                    ? AppColors.darkBorder
+                                    : AppColors.lightBlueGrey,
+                          ),
+                ),
+                child: Center(
+                  child: Text(
+                    dayLabels[i],
+                    style: TextStyle(
+                      fontFamily: 'Poppins',
+                      fontSize: 12,
+                      color:
+                          _selectedDays.contains(i + 1)
+                              ? Colors.white
+                              : isDark
+                              ? AppColors.darkBackgroundText
+                              : AppColors.lightBackgroundText,
+                    ),
+                  ),
                 ),
               ),
             ),
@@ -139,26 +149,26 @@ class _AlarmTileState extends State<AlarmTile> {
                     BoxShadow(
                       offset: const Offset(-5, -5),
                       blurRadius: 20,
-                      color: AppColors.darkGrey.withOpacity(0.35),
+                      color: AppColors.darkGrey.withValues(alpha: 0.35),
                     ),
                     BoxShadow(
                       offset: const Offset(13, 14),
                       blurRadius: 12,
                       spreadRadius: -6,
-                      color: AppColors.shadowDark.withOpacity(0.70),
+                      color: AppColors.shadowDark.withValues(alpha: 0.70),
                     ),
                   ]
                   : [
                     BoxShadow(
                       offset: const Offset(-5, -5),
                       blurRadius: 20,
-                      color: Colors.white.withOpacity(0.53),
+                      color: Colors.white.withValues(alpha: 0.53),
                     ),
                     BoxShadow(
                       offset: const Offset(13, 14),
                       blurRadius: 12,
                       spreadRadius: -6,
-                      color: AppColors.shadowLight.withOpacity(0.57),
+                      color: AppColors.shadowLight.withValues(alpha: 0.57),
                     ),
                   ],
         ),

--- a/lib/widgets/alarm_tile.dart
+++ b/lib/widgets/alarm_tile.dart
@@ -1,25 +1,49 @@
 import 'package:awake/models/alarm_model.dart';
 import 'package:awake/theme/app_colors.dart';
+import 'package:awake/widgets/gradient_switch.dart';
 import 'package:flutter/material.dart';
 
-class AlarmTile extends StatelessWidget {
+class AlarmTile extends StatefulWidget {
   final AlarmModel alarmModel;
-  final VoidCallback onDelete;
+  final ValueChanged<bool> onEnabledChanged;
+  final ValueChanged<List<int>> onDaysChanged;
+
   const AlarmTile({
     super.key,
     required this.alarmModel,
-    required this.onDelete,
+    required this.onEnabledChanged,
+    required this.onDaysChanged,
   });
+
+  @override
+  State<AlarmTile> createState() => _AlarmTileState();
+}
+
+class _AlarmTileState extends State<AlarmTile> {
+  bool _expanded = false;
+  late bool _enabled;
+  late Set<int> _selectedDays;
+
+  @override
+  void initState() {
+    super.initState();
+    _enabled = widget.alarmModel.enabled;
+    _selectedDays = widget.alarmModel.days.toSet();
+  }
+
+  @override
+  void didUpdateWidget(covariant AlarmTile oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _enabled = widget.alarmModel.enabled;
+    _selectedDays = widget.alarmModel.days.toSet();
+  }
 
   Widget _repeatDayText(bool isDark) {
     const dayLabels = ['M', 'T', 'W', 'T', 'F', 'S', 'Su'];
     final textSpans = <TextSpan>[];
 
     for (int i = 0; i < dayLabels.length; i++) {
-      final isSelected =
-          alarmModel.alarmSettings
-              .where((e) => e.dateTime.weekday == i + 1)
-              .isNotEmpty;
+      final isSelected = _selectedDays.contains(i + 1);
       final color =
           isSelected
               ? AppColors.primary
@@ -42,55 +66,63 @@ class AlarmTile extends StatelessWidget {
     );
   }
 
+  Widget _daySelector(bool isDark) {
+    const dayLabels = ['M', 'T', 'W', 'T', 'F', 'S', 'Su'];
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        for (int i = 0; i < dayLabels.length; i++)
+          GestureDetector(
+            onTap: () {
+              setState(() {
+                if (_selectedDays.contains(i + 1)) {
+                  _selectedDays.remove(i + 1);
+                } else {
+                  _selectedDays.add(i + 1);
+                }
+              });
+              widget.onDaysChanged(_selectedDays.toList());
+            },
+            child: Container(
+              padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 6),
+              decoration: BoxDecoration(
+                color:
+                    _selectedDays.contains(i + 1)
+                        ? AppColors.primary
+                        : Colors.transparent,
+                borderRadius: BorderRadius.circular(6),
+                border: Border.all(
+                  color:
+                      isDark ? AppColors.darkBorder : AppColors.lightBlueGrey,
+                ),
+              ),
+              child: Text(
+                dayLabels[i],
+                style: TextStyle(
+                  fontFamily: 'Poppins',
+                  fontSize: 12,
+                  color:
+                      _selectedDays.contains(i + 1)
+                          ? Colors.white
+                          : isDark
+                          ? AppColors.darkBackgroundText
+                          : AppColors.lightBackgroundText,
+                ),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final bool isDark = Theme.of(context).brightness == Brightness.dark;
-    return Container(
-      padding: const EdgeInsets.all(1),
-      margin: const EdgeInsets.only(top: 23),
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(20),
-        gradient: LinearGradient(
-          begin: Alignment.topLeft,
-          end: Alignment.bottomRight,
-          colors:
-              isDark
-                  ? [AppColors.darkBorder, AppColors.darkScaffold2]
-                  : [Colors.white, AppColors.lightScaffold2],
-        ),
-        boxShadow:
-            isDark
-                ? [
-                  BoxShadow(
-                    offset: const Offset(-5, -5),
-                    blurRadius: 20,
-                    color: AppColors.darkGrey.withValues(alpha: 0.35),
-                  ),
-                  BoxShadow(
-                    offset: const Offset(13, 14),
-                    blurRadius: 12,
-                    spreadRadius: -6,
-                    color: AppColors.shadowDark.withValues(alpha: 0.70),
-                  ),
-                ]
-                : [
-                  BoxShadow(
-                    offset: const Offset(-5, -5),
-                    blurRadius: 20,
-                    color: Colors.white.withValues(alpha: 0.53),
-                  ),
-                  BoxShadow(
-                    offset: const Offset(13, 14),
-                    blurRadius: 12,
-                    spreadRadius: -6,
-                    color: AppColors.shadowLight.withValues(alpha: 0.57),
-                  ),
-                ],
-      ),
+    return GestureDetector(
+      onTap: () => setState(() => _expanded = !_expanded),
       child: Container(
-        height: 74,
-        width: double.infinity,
-        padding: const EdgeInsets.symmetric(horizontal: 18),
+        padding: const EdgeInsets.all(1),
+        margin: const EdgeInsets.only(top: 23),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(20),
           gradient: LinearGradient(
@@ -98,34 +130,89 @@ class AlarmTile extends StatelessWidget {
             end: Alignment.bottomRight,
             colors:
                 isDark
-                    ? [AppColors.darkClock1, AppColors.darkScaffold1]
-                    : [AppColors.lightScaffold1, AppColors.lightGradient2],
+                    ? [AppColors.darkBorder, AppColors.darkScaffold2]
+                    : [Colors.white, AppColors.lightScaffold2],
           ),
+          boxShadow:
+              isDark
+                  ? [
+                    BoxShadow(
+                      offset: const Offset(-5, -5),
+                      blurRadius: 20,
+                      color: AppColors.darkGrey.withOpacity(0.35),
+                    ),
+                    BoxShadow(
+                      offset: const Offset(13, 14),
+                      blurRadius: 12,
+                      spreadRadius: -6,
+                      color: AppColors.shadowDark.withOpacity(0.70),
+                    ),
+                  ]
+                  : [
+                    BoxShadow(
+                      offset: const Offset(-5, -5),
+                      blurRadius: 20,
+                      color: Colors.white.withOpacity(0.53),
+                    ),
+                    BoxShadow(
+                      offset: const Offset(13, 14),
+                      blurRadius: 12,
+                      spreadRadius: -6,
+                      color: AppColors.shadowLight.withOpacity(0.57),
+                    ),
+                  ],
         ),
-        child: Row(
-          children: [
-            Text(
-              "${alarmModel.timeOfDay.hour < 10 ? "0${alarmModel.timeOfDay.hour}" : alarmModel.timeOfDay.hour}:${alarmModel.timeOfDay.minute < 10 ? "0${alarmModel.timeOfDay.minute}" : alarmModel.timeOfDay.minute}",
-              style: TextStyle(
-                color:
-                    isDark
-                        ? AppColors.darkBackgroundText
-                        : AppColors.lightBackgroundText,
-                fontFamily: 'Poppins',
-                fontSize: 34,
-                fontWeight: FontWeight.w500,
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 200),
+          height: _expanded ? 120 : 74,
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(horizontal: 18),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors:
+                  isDark
+                      ? [AppColors.darkClock1, AppColors.darkScaffold1]
+                      : [AppColors.lightScaffold1, AppColors.lightGradient2],
+            ),
+          ),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Row(
+                children: [
+                  Text(
+                    "${widget.alarmModel.timeOfDay.hour.toString().padLeft(2, '0')}:${widget.alarmModel.timeOfDay.minute.toString().padLeft(2, '0')}",
+                    style: TextStyle(
+                      color:
+                          isDark
+                              ? AppColors.darkBackgroundText
+                              : AppColors.lightBackgroundText,
+                      fontFamily: 'Poppins',
+                      fontSize: 34,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const Spacer(),
+                  _repeatDayText(isDark),
+                  const SizedBox(width: 12),
+                  GradientSwitch(
+                    value: _enabled,
+                    onChanged: (v) {
+                      setState(() => _enabled = v);
+                      widget.onEnabledChanged(v);
+                    },
+                  ),
+                ],
               ),
-            ),
-            const Spacer(),
-            if (alarmModel.alarmSettings.isNotEmpty) _repeatDayText(isDark),
-            const SizedBox(width: 12),
-            IconButton(
-              onPressed: onDelete,
-              tooltip: "Delete",
-              icon: const Icon(Icons.delete),
-              style: IconButton.styleFrom(foregroundColor: AppColors.primary),
-            ),
-          ],
+              if (_expanded) ...[
+                const SizedBox(height: 12),
+                _daySelector(isDark),
+              ],
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- keep track of enabled state and repeat days for each alarm
- update DB schema for storing enabled flag
- allow enabling/disabling alarms and editing repeat days
- make AlarmTile expandable with switch and weekday selector
- reduce calls to `Alarm.getAlarms()` by reusing previously fetched lists

## Testing
- `dart format lib`
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_686996995dcc832485079bd54c7c7cba