### PR TITLE
Add alarm edit dialog

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -291,6 +291,10 @@ class _HomeState extends State<Home> {
                                                 alarms[index].timeOfDay,
                                                 days,
                                               ),
+                                      onDelete:
+                                          () => context
+                                              .read<AlarmCubit>()
+                                              .deleteAlarmModel(alarms[index]),
                                     ),
                                 ],
                               ],

--- a/lib/widgets/alarm_tile.dart
+++ b/lib/widgets/alarm_tile.dart
@@ -7,12 +7,14 @@ class AlarmTile extends StatefulWidget {
   final AlarmModel alarmModel;
   final ValueChanged<bool> onEnabledChanged;
   final ValueChanged<List<int>> onDaysChanged;
+  final VoidCallback onDelete;
 
   const AlarmTile({
     super.key,
     required this.alarmModel,
     required this.onEnabledChanged,
     required this.onDaysChanged,
+    required this.onDelete,
   });
 
   @override
@@ -20,7 +22,6 @@ class AlarmTile extends StatefulWidget {
 }
 
 class _AlarmTileState extends State<AlarmTile> {
-  bool _expanded = false;
   late bool _enabled;
   late Set<int> _selectedDays;
 
@@ -66,7 +67,11 @@ class _AlarmTileState extends State<AlarmTile> {
     );
   }
 
-  Widget _daySelector(bool isDark) {
+  Widget _daySelector(
+    Set<int> days,
+    bool isDark,
+    ValueChanged<Set<int>> onChanged,
+  ) {
     const dayLabels = ['M', 'T', 'W', 'T', 'F', 'S', 'Su'];
     return Row(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
@@ -74,14 +79,13 @@ class _AlarmTileState extends State<AlarmTile> {
         for (int i = 0; i < dayLabels.length; i++)
           GestureDetector(
             onTap: () {
-              setState(() {
-                if (_selectedDays.contains(i + 1)) {
-                  _selectedDays.remove(i + 1);
-                } else {
-                  _selectedDays.add(i + 1);
-                }
-              });
-              widget.onDaysChanged(_selectedDays.toList());
+              final newDays = <int>{...days};
+              if (newDays.contains(i + 1)) {
+                newDays.remove(i + 1);
+              } else {
+                newDays.add(i + 1);
+              }
+              onChanged(newDays);
             },
             child: SizedBox(
               height: 24,
@@ -90,11 +94,11 @@ class _AlarmTileState extends State<AlarmTile> {
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
                   color:
-                      _selectedDays.contains(i + 1)
+                      days.contains(i + 1)
                           ? AppColors.primary
                           : Colors.transparent,
                   border:
-                      _selectedDays.contains(i + 1)
+                      days.contains(i + 1)
                           ? null
                           : Border.all(
                             color:
@@ -110,7 +114,7 @@ class _AlarmTileState extends State<AlarmTile> {
                       fontFamily: 'Poppins',
                       fontSize: 12,
                       color:
-                          _selectedDays.contains(i + 1)
+                          days.contains(i + 1)
                               ? Colors.white
                               : isDark
                               ? AppColors.darkBackgroundText
@@ -125,11 +129,65 @@ class _AlarmTileState extends State<AlarmTile> {
     );
   }
 
+  Future<void> _showEditDialog() async {
+    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    var tempDays = {..._selectedDays};
+    await showDialog<void>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setStateDialog) {
+            return AlertDialog(
+              backgroundColor:
+                  isDark ? AppColors.darkScaffold1 : AppColors.lightScaffold1,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(20),
+              ),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _daySelector(tempDays, isDark, (d) {
+                    setStateDialog(() => tempDays = d);
+                  }),
+                  const SizedBox(height: 16),
+                  TextButton.icon(
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      widget.onDelete();
+                    },
+                    icon: const Icon(Icons.delete),
+                    label: const Text('Delete Alarm'),
+                  ),
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Cancel'),
+                ),
+                TextButton(
+                  onPressed: () {
+                    setState(() {
+                      _selectedDays = tempDays;
+                    });
+                    widget.onDaysChanged(_selectedDays.toList());
+                    Navigator.of(context).pop();
+                  },
+                  child: const Text('Save'),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final bool isDark = Theme.of(context).brightness == Brightness.dark;
     return GestureDetector(
-      onTap: () => setState(() => _expanded = !_expanded),
+      onTap: _showEditDialog,
       child: Container(
         padding: const EdgeInsets.all(1),
         margin: const EdgeInsets.only(top: 23),
@@ -172,9 +230,8 @@ class _AlarmTileState extends State<AlarmTile> {
                     ),
                   ],
         ),
-        child: AnimatedContainer(
-          duration: const Duration(milliseconds: 200),
-          height: _expanded ? 120 : 74,
+        child: Container(
+          height: 74,
           width: double.infinity,
           padding: const EdgeInsets.symmetric(horizontal: 18),
           decoration: BoxDecoration(
@@ -217,10 +274,6 @@ class _AlarmTileState extends State<AlarmTile> {
                   ),
                 ],
               ),
-              if (_expanded) ...[
-                const SizedBox(height: 12),
-                _daySelector(isDark),
-              ],
             ],
           ),
         ),

--- a/lib/widgets/alarm_tile.dart
+++ b/lib/widgets/alarm_tile.dart
@@ -131,7 +131,6 @@ class _AlarmTileState extends State<AlarmTile> {
 
   Future<void> _showEditDialog() async {
     final bool isDark = Theme.of(context).brightness == Brightness.dark;
-    var tempDays = {..._selectedDays};
     await showDialog<void>(
       context: context,
       builder: (context) {
@@ -146,8 +145,22 @@ class _AlarmTileState extends State<AlarmTile> {
               content: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  _daySelector(tempDays, isDark, (d) {
-                    setStateDialog(() => tempDays = d);
+                  Text(
+                    "${widget.alarmModel.timeOfDay.hour.toString().padLeft(2, '0')}:${widget.alarmModel.timeOfDay.minute.toString().padLeft(2, '0')}",
+                    style: TextStyle(
+                      color: isDark
+                          ? AppColors.darkBackgroundText
+                          : AppColors.lightBackgroundText,
+                      fontFamily: 'Poppins',
+                      fontSize: 34,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  _daySelector(_selectedDays, isDark, (d) {
+                    setState(() => _selectedDays = d);
+                    setStateDialog(() {});
+                    widget.onDaysChanged(_selectedDays.toList());
                   }),
                   const SizedBox(height: 16),
                   TextButton.icon(
@@ -160,22 +173,6 @@ class _AlarmTileState extends State<AlarmTile> {
                   ),
                 ],
               ),
-              actions: [
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: const Text('Cancel'),
-                ),
-                TextButton(
-                  onPressed: () {
-                    setState(() {
-                      _selectedDays = tempDays;
-                    });
-                    widget.onDaysChanged(_selectedDays.toList());
-                    Navigator.of(context).pop();
-                  },
-                  child: const Text('Save'),
-                ),
-              ],
             );
           },
         );


### PR DESCRIPTION
## Summary
- replace expanding alarm tile with standard tile
- open a dialog on tap for editing days or deleting an alarm
- wire up delete functionality

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_686a045fe83c8324b2141e5c9e166b56