### PR TITLE
Fix day editing side effects in alarm tile

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -284,6 +284,7 @@ class _HomeState extends State<Home> {
                                     index++
                                   )
                                     AlarmTile(
+                                      key: ValueKey(alarms[index].timeOfDay),
                                       alarmModel: alarms[index],
                                       onEnabledChanged:
                                           (v) => context

--- a/lib/services/alarm_cubit.dart
+++ b/lib/services/alarm_cubit.dart
@@ -192,7 +192,7 @@ class AlarmCubit extends Cubit<List<AlarmModel>> {
 
   Future<void> updateAlarmDays(TimeOfDay timeOfDay, List<int> days) async {
     final entry = await AlarmDatabase.getAlarm(timeOfDay);
-    final enabled = entry?.enabled ?? true;
+    final bool enabled = days.isNotEmpty && (entry?.enabled ?? true);
     await AlarmDatabase.insertOrUpdate(
       AlarmDbEntry(time: timeOfDay, days: days, enabled: enabled),
     );

--- a/lib/widgets/alarm_tile.dart
+++ b/lib/widgets/alarm_tile.dart
@@ -179,6 +179,10 @@ class _AlarmTileState extends State<AlarmTile> {
                   const SizedBox(height: 20),
                   _daySelector(_selectedDays, isDark, (d) {
                     setState(() => _selectedDays = d);
+                    if (_selectedDays.isEmpty && _enabled) {
+                      setState(() => _enabled = false);
+                      widget.onEnabledChanged(false);
+                    }
                     setStateDialog(() {});
                     widget.onDaysChanged(_selectedDays.toList());
                   }),


### PR DESCRIPTION
## Summary
- keep AlarmTile state with ValueKey
- disable alarm when all days are removed in UI
- mark alarm disabled on cubit update

## Testing
- `dart format lib/screens/home.dart lib/widgets/alarm_tile.dart lib/services/alarm_cubit.dart`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_686ad64469e083249227a5d4ce756e56