### PR TITLE
Add alarm volume controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ A alarm clock app using flutter
 - Toggle 12-hour or 24-hour time format in Settings.
 - Enable or disable vibration when alarms ring. Changing the preference
   updates all existing alarms.
+- Choose a fixed alarm volume using a slider in Settings.
+- Enable a gradual fade in for alarm volume.

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -287,12 +287,242 @@ class SettingsScreen extends StatelessWidget {
                                             context.read<SettingsCubit>();
                                         final alarmCubit =
                                             context.read<AlarmCubit>();
-                                        await settingsCubit.setVibrationEnabled(v);
-                                        await alarmCubit.updateVibrationForAll(v);
+                                        await settingsCubit.setVibrationEnabled(
+                                          v,
+                                        );
+                                        await alarmCubit.updateVibrationForAll(
+                                          v,
+                                        );
                                       },
                                     ),
                                   ],
                                 ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 23),
+                          GestureDetector(
+                            onTap: () async {
+                              final settingsCubit =
+                                  context.read<SettingsCubit>();
+                              final alarmCubit = context.read<AlarmCubit>();
+                              final newValue = !state.fadeInAlarm;
+                              await settingsCubit.setFadeInAlarm(newValue);
+                              await alarmCubit.updateVolumeSettingsForAll(
+                                fadeIn: newValue,
+                                volume: state.alarmVolume,
+                              );
+                            },
+                            child: Container(
+                              padding: const EdgeInsets.all(1),
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(20),
+                                gradient: LinearGradient(
+                                  begin: Alignment.topLeft,
+                                  end: Alignment.bottomRight,
+                                  colors:
+                                      isDark
+                                          ? [
+                                            AppColors.darkBorder,
+                                            AppColors.darkScaffold2,
+                                          ]
+                                          : [
+                                            Colors.white,
+                                            AppColors.lightScaffold2,
+                                          ],
+                                ),
+                                boxShadow:
+                                    isDark
+                                        ? [
+                                          BoxShadow(
+                                            offset: const Offset(-5, -5),
+                                            blurRadius: 20,
+                                            color: AppColors.darkGrey
+                                                .withValues(alpha: 0.35),
+                                          ),
+                                          BoxShadow(
+                                            offset: const Offset(13, 14),
+                                            blurRadius: 12,
+                                            spreadRadius: -6,
+                                            color: AppColors.shadowDark
+                                                .withValues(alpha: 0.70),
+                                          ),
+                                        ]
+                                        : [
+                                          BoxShadow(
+                                            offset: const Offset(-5, -5),
+                                            blurRadius: 20,
+                                            color: Colors.white.withValues(
+                                              alpha: 0.53,
+                                            ),
+                                          ),
+                                          BoxShadow(
+                                            offset: const Offset(13, 14),
+                                            blurRadius: 12,
+                                            spreadRadius: -6,
+                                            color: AppColors.shadowLight
+                                                .withValues(alpha: 0.57),
+                                          ),
+                                        ],
+                              ),
+                              child: Container(
+                                height: 74,
+                                width: double.infinity,
+                                padding: const EdgeInsets.symmetric(
+                                  horizontal: 18,
+                                ),
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(20),
+                                  gradient: LinearGradient(
+                                    begin: Alignment.topLeft,
+                                    end: Alignment.bottomRight,
+                                    colors:
+                                        isDark
+                                            ? [
+                                              AppColors.darkClock1,
+                                              AppColors.darkScaffold1,
+                                            ]
+                                            : [
+                                              AppColors.lightScaffold1,
+                                              AppColors.lightGradient2,
+                                            ],
+                                  ),
+                                ),
+                                child: Row(
+                                  children: [
+                                    Text(
+                                      'Gradual Fade In',
+                                      style: TextStyle(
+                                        color: color,
+                                        fontFamily: 'Poppins',
+                                      ),
+                                    ),
+                                    const Spacer(),
+                                    GradientSwitch(
+                                      value: state.fadeInAlarm,
+                                      onChanged: (v) async {
+                                        final settingsCubit =
+                                            context.read<SettingsCubit>();
+                                        final alarmCubit =
+                                            context.read<AlarmCubit>();
+                                        await settingsCubit.setFadeInAlarm(v);
+                                        await alarmCubit
+                                            .updateVolumeSettingsForAll(
+                                              fadeIn: v,
+                                              volume: state.alarmVolume,
+                                            );
+                                      },
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 23),
+                          Container(
+                            padding: const EdgeInsets.all(1),
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(20),
+                              gradient: LinearGradient(
+                                begin: Alignment.topLeft,
+                                end: Alignment.bottomRight,
+                                colors:
+                                    isDark
+                                        ? [
+                                          AppColors.darkBorder,
+                                          AppColors.darkScaffold2,
+                                        ]
+                                        : [
+                                          Colors.white,
+                                          AppColors.lightScaffold2,
+                                        ],
+                              ),
+                              boxShadow:
+                                  isDark
+                                      ? [
+                                        BoxShadow(
+                                          offset: const Offset(-5, -5),
+                                          blurRadius: 20,
+                                          color: AppColors.darkGrey.withValues(
+                                            alpha: 0.35,
+                                          ),
+                                        ),
+                                        BoxShadow(
+                                          offset: const Offset(13, 14),
+                                          blurRadius: 12,
+                                          spreadRadius: -6,
+                                          color: AppColors.shadowDark
+                                              .withValues(alpha: 0.70),
+                                        ),
+                                      ]
+                                      : [
+                                        BoxShadow(
+                                          offset: const Offset(-5, -5),
+                                          blurRadius: 20,
+                                          color: Colors.white.withValues(
+                                            alpha: 0.53,
+                                          ),
+                                        ),
+                                        BoxShadow(
+                                          offset: const Offset(13, 14),
+                                          blurRadius: 12,
+                                          spreadRadius: -6,
+                                          color: AppColors.shadowLight
+                                              .withValues(alpha: 0.57),
+                                        ),
+                                      ],
+                            ),
+                            child: Container(
+                              height: 74,
+                              width: double.infinity,
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 18,
+                              ),
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(20),
+                                gradient: LinearGradient(
+                                  begin: Alignment.topLeft,
+                                  end: Alignment.bottomRight,
+                                  colors:
+                                      isDark
+                                          ? [
+                                            AppColors.darkClock1,
+                                            AppColors.darkScaffold1,
+                                          ]
+                                          : [
+                                            AppColors.lightScaffold1,
+                                            AppColors.lightGradient2,
+                                          ],
+                                ),
+                              ),
+                              child: Row(
+                                children: [
+                                  Icon(
+                                    state.alarmVolume > 0.7
+                                        ? Icons.volume_up_rounded
+                                        : state.alarmVolume > 0.1
+                                        ? Icons.volume_down_rounded
+                                        : Icons.volume_mute_rounded,
+                                    color: color,
+                                  ),
+                                  Expanded(
+                                    child: Slider(
+                                      value: state.alarmVolume,
+                                      onChanged: (v) async {
+                                        final settingsCubit =
+                                            context.read<SettingsCubit>();
+                                        final alarmCubit =
+                                            context.read<AlarmCubit>();
+                                        await settingsCubit.setAlarmVolume(v);
+                                        await alarmCubit
+                                            .updateVolumeSettingsForAll(
+                                              fadeIn: state.fadeInAlarm,
+                                              volume: v,
+                                            );
+                                      },
+                                    ),
+                                  ),
+                                ],
                               ),
                             ),
                           ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -2,6 +2,7 @@ import 'package:awake/extensions/context_extensions.dart';
 import 'package:awake/services/alarm_cubit.dart';
 import 'package:awake/services/settings_cubit.dart';
 import 'package:awake/theme/app_colors.dart';
+import 'package:awake/widgets/gradient_slider.dart';
 import 'package:awake/widgets/gradient_switch.dart';
 import 'package:awake/widgets/theme_list_tile.dart';
 
@@ -505,8 +506,9 @@ class SettingsScreen extends StatelessWidget {
                                         : Icons.volume_mute_rounded,
                                     color: color,
                                   ),
+                                  const SizedBox(width: 10),
                                   Expanded(
-                                    child: Slider(
+                                    child: GradientSlider(
                                       value: state.alarmVolume,
                                       onChanged: (v) async {
                                         final settingsCubit =

--- a/lib/services/alarm_cubit.dart
+++ b/lib/services/alarm_cubit.dart
@@ -59,10 +59,11 @@ class AlarmCubit extends Cubit<List<AlarmModel>> {
       final volumeSettings =
           fadeIn
               ? VolumeSettings.fade(
-                fadeDuration: const Duration(seconds: 5),
+                fadeDuration: const Duration(seconds: 60),
                 volume: volume,
+                volumeEnforced: true,
               )
-              : VolumeSettings.fixed(volume: volume);
+              : VolumeSettings.fixed(volume: volume, volumeEnforced: true);
       final alarmSetting = AlarmSettings(
         id: id,
         dateTime: scheduledDate,

--- a/lib/services/settings_cubit.dart
+++ b/lib/services/settings_cubit.dart
@@ -6,22 +6,30 @@ class SettingsState {
   final ThemeMode mode;
   final bool use24HourFormat;
   final bool vibrationEnabled;
+  final bool fadeInAlarm;
+  final double alarmVolume;
 
   const SettingsState({
     required this.mode,
     required this.use24HourFormat,
     required this.vibrationEnabled,
+    required this.fadeInAlarm,
+    required this.alarmVolume,
   });
 
   SettingsState copyWith({
     ThemeMode? mode,
     bool? use24HourFormat,
     bool? vibrationEnabled,
+    bool? fadeInAlarm,
+    double? alarmVolume,
   }) {
     return SettingsState(
       mode: mode ?? this.mode,
       use24HourFormat: use24HourFormat ?? this.use24HourFormat,
       vibrationEnabled: vibrationEnabled ?? this.vibrationEnabled,
+      fadeInAlarm: fadeInAlarm ?? this.fadeInAlarm,
+      alarmVolume: alarmVolume ?? this.alarmVolume,
     );
   }
 }
@@ -47,6 +55,13 @@ class SettingsCubit extends Cubit<SettingsState> {
                   ) ??
                   1) ==
               1,
+          fadeInAlarm:
+              (SharedPreferencesWithCache.instance.get<int>('fadeInAlarm') ??
+                  0) ==
+              1,
+          alarmVolume:
+              SharedPreferencesWithCache.instance.get<double>('alarmVolume') ??
+              1.0,
         ),
       );
 
@@ -69,5 +84,18 @@ class SettingsCubit extends Cubit<SettingsState> {
       enabled ? 1 : 0,
     );
     emit(state.copyWith(vibrationEnabled: enabled));
+  }
+
+  Future<void> setFadeInAlarm(bool enabled) async {
+    await SharedPreferencesWithCache.instance.setInt(
+      'fadeInAlarm',
+      enabled ? 1 : 0,
+    );
+    emit(state.copyWith(fadeInAlarm: enabled));
+  }
+
+  Future<void> setAlarmVolume(double volume) async {
+    await SharedPreferencesWithCache.instance.setDouble('alarmVolume', volume);
+    emit(state.copyWith(alarmVolume: volume));
   }
 }

--- a/lib/services/shared_prefs_with_cache.dart
+++ b/lib/services/shared_prefs_with_cache.dart
@@ -33,4 +33,9 @@ class SharedPreferencesWithCache {
     _cache[key] = value;
     return _prefs.setInt(key, value);
   }
+
+  Future<bool> setDouble(String key, double value) async {
+    _cache[key] = value;
+    return _prefs.setDouble(key, value);
+  }
 }

--- a/lib/widgets/add_button.dart
+++ b/lib/widgets/add_button.dart
@@ -8,7 +8,7 @@ class AddButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final bool isDark = Theme.brightnessOf(context) == Brightness.dark;
     return DecoratedBox(
       decoration: BoxDecoration(
         gradient: LinearGradient(

--- a/lib/widgets/alarm_tile.dart
+++ b/lib/widgets/alarm_tile.dart
@@ -132,7 +132,7 @@ class _AlarmTileState extends State<AlarmTile> {
   }
 
   Future<void> _showEditDialog() async {
-    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final bool isDark = Theme.brightnessOf(context) == Brightness.dark;
     final bool use24h = context.read<SettingsCubit>().state.use24HourFormat;
     await showDialog<void>(
       context: context,
@@ -206,7 +206,7 @@ class _AlarmTileState extends State<AlarmTile> {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final bool isDark = Theme.brightnessOf(context) == Brightness.dark;
     final bool use24h = context.watch<SettingsCubit>().state.use24HourFormat;
     return Padding(
       padding: const EdgeInsets.only(top: 23),

--- a/lib/widgets/clock.dart
+++ b/lib/widgets/clock.dart
@@ -22,7 +22,7 @@ class _ClockWidgetState extends State<ClockWidget> {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final bool isDark = Theme.brightnessOf(context) == Brightness.dark;
     return CustomPaint(
       size: Size.infinite,
       willChange: true,

--- a/lib/widgets/gradient_slider.dart
+++ b/lib/widgets/gradient_slider.dart
@@ -1,0 +1,168 @@
+import 'package:awake/theme/app_colors.dart';
+import 'package:flutter/material.dart' hide BoxDecoration, BoxShadow;
+import 'package:flutter_inset_box_shadow_update/flutter_inset_box_shadow_update.dart';
+
+class GradientSlider extends StatefulWidget {
+  final double value;
+  final ValueChanged<double> onChanged;
+  final double min;
+  final double max;
+
+  const GradientSlider({
+    super.key,
+    required this.value,
+    required this.onChanged,
+    this.min = 0.0,
+    this.max = 1.0,
+  });
+
+  @override
+  State<GradientSlider> createState() => _GradientSliderState();
+}
+
+class _GradientSliderState extends State<GradientSlider> {
+  late double _value;
+  final double thumbRadius = 12;
+
+  @override
+  void initState() {
+    super.initState();
+    _value = widget.value.clamp(widget.min, widget.max);
+  }
+
+  @override
+  void didUpdateWidget(covariant GradientSlider oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.value != widget.value) {
+      _value = widget.value.clamp(widget.min, widget.max);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.brightnessOf(context) == Brightness.dark;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final fullWidth = constraints.maxWidth;
+        final trackLeft = thumbRadius;
+        final trackRight = fullWidth - thumbRadius;
+        final trackWidth = trackRight - trackLeft;
+
+        final progress = (_value - widget.min) / (widget.max - widget.min);
+        final thumbX = (progress * trackWidth) + trackLeft;
+
+        return GestureDetector(
+          behavior: HitTestBehavior.translucent,
+          onPanUpdate: (details) {
+            final dx = details.localPosition.dx.clamp(trackLeft, trackRight);
+            final newProgress = (dx - trackLeft) / trackWidth;
+            final newValue =
+                widget.min + newProgress * (widget.max - widget.min);
+            setState(() => _value = newValue);
+            widget.onChanged(_value);
+          },
+          child: SizedBox(
+            height: 48,
+            child: Stack(
+              alignment: Alignment.centerLeft,
+              children: [
+                // Inactive track
+                Positioned(
+                  left: trackLeft,
+                  right: thumbRadius,
+                  child: Container(
+                    height: 6,
+                    decoration: BoxDecoration(
+                      color:
+                          isDark
+                              ? AppColors.shadowDark.withValues(alpha: 0.25)
+                              : AppColors.shadowLight.withValues(alpha: 0.25),
+                      borderRadius: BorderRadius.circular(6),
+                      boxShadow: [
+                        BoxShadow(
+                          offset: const Offset(1.5, 1.5),
+                          blurRadius: 3,
+                          color:
+                              isDark
+                                  ? AppColors.shadowDark.withValues(alpha: 0.4)
+                                  : AppColors.lightBackgroundText.withValues(
+                                    alpha: 0.4,
+                                  ),
+                          inset: true,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+
+                // Active track (gradient)
+                Positioned(
+                  left: trackLeft,
+                  child: Container(
+                    height: 6,
+                    width: thumbX - trackLeft,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(6),
+                      gradient: const LinearGradient(
+                        colors: [AppColors.primary, AppColors.primaryLight],
+                      ),
+                    ),
+                  ),
+                ),
+
+                // Thumb (always visible)
+                Positioned(
+                  left: thumbX - thumbRadius,
+                  child: Container(
+                    width: thumbRadius * 2,
+                    height: thumbRadius * 2,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      gradient:
+                          isDark
+                              ? null
+                              : const LinearGradient(
+                                begin: Alignment.bottomLeft,
+                                end: Alignment.topRight,
+                                colors: [
+                                  AppColors.lightScaffold1,
+                                  AppColors.lightGradient2,
+                                ],
+                              ),
+                      color: isDark ? AppColors.lightScaffold2 : null,
+                      boxShadow: [
+                        BoxShadow(
+                          offset: const Offset(-3, -3),
+                          blurRadius: 6,
+                          color:
+                              isDark
+                                  ? const Color(
+                                    0xFF454D56,
+                                  ).withValues(alpha: 0.5)
+                                  : Colors.white.withValues(alpha: 0.8),
+                        ),
+                        BoxShadow(
+                          offset: const Offset(3, 3),
+                          blurRadius: 6,
+                          color:
+                              isDark
+                                  ? const Color(
+                                    0xFF181E24,
+                                  ).withValues(alpha: 0.6)
+                                  : const Color(
+                                    0xFFA6B4C8,
+                                  ).withValues(alpha: 0.6),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/lib/widgets/gradient_switch.dart
+++ b/lib/widgets/gradient_switch.dart
@@ -35,7 +35,7 @@ class _GradientSwitchState extends State<GradientSwitch> {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final bool isDark = Theme.brightnessOf(context) == Brightness.dark;
     return GestureDetector(
       onTap: () {
         setState(() {

--- a/lib/widgets/minus_button.dart
+++ b/lib/widgets/minus_button.dart
@@ -8,7 +8,7 @@ class MinusButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final bool isDark = Theme.brightnessOf(context) == Brightness.dark;
 
     return DecoratedBox(
       decoration: BoxDecoration(

--- a/lib/widgets/snooze_button.dart
+++ b/lib/widgets/snooze_button.dart
@@ -27,7 +27,7 @@ class _SnoozeButtonState extends State<SnoozeButton> {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final bool isDark = Theme.brightnessOf(context) == Brightness.dark;
 
     return Row(
       children: [

--- a/lib/widgets/stop_alarm.dart
+++ b/lib/widgets/stop_alarm.dart
@@ -8,7 +8,7 @@ class StopButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final bool isDark = Theme.of(context).brightness == Brightness.dark;
+    final bool isDark = Theme.brightnessOf(context) == Brightness.dark;
     return DecoratedBox(
       decoration: BoxDecoration(
         gradient: LinearGradient(


### PR DESCRIPTION
## Summary
- support saving double values in prefs
- add fade-in and volume options to settings cubit
- apply volume prefs when scheduling alarms
- update alarms when volume settings change
- expose UI toggles and slider for fade-in and volume
- document the new features

## Testing
- `dart format lib`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_686aed6504988324874abb8add007f29