### PR TITLE
Refactor settings page UI with reusable tile

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -7,6 +7,7 @@ import 'package:awake/services/settings_cubit.dart';
 import 'package:awake/theme/app_colors.dart';
 import 'package:awake/widgets/gradient_slider.dart';
 import 'package:awake/widgets/gradient_switch.dart';
+import 'package:awake/widgets/settings_tile.dart';
 import 'package:awake/widgets/theme_list_tile.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
@@ -91,112 +92,27 @@ class SettingsScreen extends StatelessWidget {
                   onChanged: (m) => context.read<SettingsCubit>().setTheme(m),
                 ),
                 const SizedBox(height: 23),
-                GestureDetector(
-                  onTap:
-                      () => context.read<SettingsCubit>().setUse24HourFormat(
-                        !state.use24HourFormat,
+                SettingsTile(
+                  onTap: () =>
+                      context.read<SettingsCubit>().setUse24HourFormat(!state.use24HourFormat),
+                  child: Row(
+                    children: [
+                      Text(
+                        '24-Hour Format',
+                        style: TextStyle(color: color, fontFamily: 'Poppins'),
                       ),
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(20),
-                      gradient: LinearGradient(
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                        colors:
-                            isDark
-                                ? [
-                                  AppColors.darkBorder,
-                                  AppColors.darkScaffold2,
-                                ]
-                                : [Colors.white, AppColors.lightScaffold2],
+                      const Spacer(),
+                      GradientSwitch(
+                        value: state.use24HourFormat,
+                        onChanged: (v) => context
+                            .read<SettingsCubit>()
+                            .setUse24HourFormat(v),
                       ),
-                      boxShadow:
-                          isDark
-                              ? [
-                                BoxShadow(
-                                  offset: const Offset(-5, -5),
-                                  blurRadius: 20,
-                                  color: AppColors.darkGrey.withValues(
-                                    alpha: 0.35,
-                                  ),
-                                ),
-                                BoxShadow(
-                                  offset: const Offset(13, 14),
-                                  blurRadius: 12,
-                                  spreadRadius: -6,
-                                  color: AppColors.shadowDark.withValues(
-                                    alpha: 0.70,
-                                  ),
-                                ),
-                              ]
-                              : [
-                                BoxShadow(
-                                  offset: const Offset(-5, -5),
-                                  blurRadius: 20,
-                                  color: Colors.white.withValues(alpha: 0.53),
-                                ),
-                                BoxShadow(
-                                  offset: const Offset(13, 14),
-                                  blurRadius: 12,
-                                  spreadRadius: -6,
-                                  color: AppColors.shadowLight.withValues(
-                                    alpha: 0.57,
-                                  ),
-                                ),
-                              ],
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(1),
-                      child: SizedBox(
-                        height: 74,
-                        width: double.infinity,
-                        child: DecoratedBox(
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(20),
-                            gradient: LinearGradient(
-                              begin: Alignment.topLeft,
-                              end: Alignment.bottomRight,
-                              colors:
-                                  isDark
-                                      ? [
-                                        AppColors.darkClock1,
-                                        AppColors.darkScaffold1,
-                                      ]
-                                      : [
-                                        AppColors.lightScaffold1,
-                                        AppColors.lightGradient2,
-                                      ],
-                            ),
-                          ),
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 18),
-                            child: Row(
-                              children: [
-                                Text(
-                                  '24-Hour Format',
-                                  style: TextStyle(
-                                    color: color,
-                                    fontFamily: 'Poppins',
-                                  ),
-                                ),
-                                const Spacer(),
-                                GradientSwitch(
-                                  value: state.use24HourFormat,
-                                  onChanged:
-                                      (v) => context
-                                          .read<SettingsCubit>()
-                                          .setUse24HourFormat(v),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ),
-                    ),
+                    ],
                   ),
                 ),
                 const SizedBox(height: 23),
-                GestureDetector(
+                SettingsTile(
                   onTap: () async {
                     final settingsCubit = context.read<SettingsCubit>();
                     final alarmCubit = context.read<AlarmCubit>();
@@ -204,111 +120,27 @@ class SettingsScreen extends StatelessWidget {
                     await settingsCubit.setVibrationEnabled(newValue);
                     await alarmCubit.updateVibrationForAll(newValue);
                   },
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(20),
-                      gradient: LinearGradient(
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                        colors:
-                            isDark
-                                ? [
-                                  AppColors.darkBorder,
-                                  AppColors.darkScaffold2,
-                                ]
-                                : [Colors.white, AppColors.lightScaffold2],
+                  child: Row(
+                    children: [
+                      Text(
+                        'Vibration',
+                        style: TextStyle(color: color, fontFamily: 'Poppins'),
                       ),
-                      boxShadow:
-                          isDark
-                              ? [
-                                BoxShadow(
-                                  offset: const Offset(-5, -5),
-                                  blurRadius: 20,
-                                  color: AppColors.darkGrey.withValues(
-                                    alpha: 0.35,
-                                  ),
-                                ),
-                                BoxShadow(
-                                  offset: const Offset(13, 14),
-                                  blurRadius: 12,
-                                  spreadRadius: -6,
-                                  color: AppColors.shadowDark.withValues(
-                                    alpha: 0.70,
-                                  ),
-                                ),
-                              ]
-                              : [
-                                BoxShadow(
-                                  offset: const Offset(-5, -5),
-                                  blurRadius: 20,
-                                  color: Colors.white.withValues(alpha: 0.53),
-                                ),
-                                BoxShadow(
-                                  offset: const Offset(13, 14),
-                                  blurRadius: 12,
-                                  spreadRadius: -6,
-                                  color: AppColors.shadowLight.withValues(
-                                    alpha: 0.57,
-                                  ),
-                                ),
-                              ],
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(1),
-                      child: SizedBox(
-                        height: 74,
-                        width: double.infinity,
-                        child: DecoratedBox(
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(20),
-                            gradient: LinearGradient(
-                              begin: Alignment.topLeft,
-                              end: Alignment.bottomRight,
-                              colors:
-                                  isDark
-                                      ? [
-                                        AppColors.darkClock1,
-                                        AppColors.darkScaffold1,
-                                      ]
-                                      : [
-                                        AppColors.lightScaffold1,
-                                        AppColors.lightGradient2,
-                                      ],
-                            ),
-                          ),
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 18),
-                            child: Row(
-                              children: [
-                                Text(
-                                  'Vibration',
-                                  style: TextStyle(
-                                    color: color,
-                                    fontFamily: 'Poppins',
-                                  ),
-                                ),
-                                const Spacer(),
-                                GradientSwitch(
-                                  value: state.vibrationEnabled,
-                                  onChanged: (v) async {
-                                    final settingsCubit =
-                                        context.read<SettingsCubit>();
-                                    final alarmCubit =
-                                        context.read<AlarmCubit>();
-                                    await settingsCubit.setVibrationEnabled(v);
-                                    await alarmCubit.updateVibrationForAll(v);
-                                  },
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
+                      const Spacer(),
+                      GradientSwitch(
+                        value: state.vibrationEnabled,
+                        onChanged: (v) async {
+                          final settingsCubit = context.read<SettingsCubit>();
+                          final alarmCubit = context.read<AlarmCubit>();
+                          await settingsCubit.setVibrationEnabled(v);
+                          await alarmCubit.updateVibrationForAll(v);
+                        },
                       ),
-                    ),
+                    ],
                   ),
                 ),
                 const SizedBox(height: 23),
-                GestureDetector(
+                SettingsTile(
                   onTap: () async {
                     final settingsCubit = context.read<SettingsCubit>();
                     final alarmCubit = context.read<AlarmCubit>();
@@ -319,110 +151,26 @@ class SettingsScreen extends StatelessWidget {
                       volume: state.alarmVolume,
                     );
                   },
-                  child: DecoratedBox(
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(20),
-                      gradient: LinearGradient(
-                        begin: Alignment.topLeft,
-                        end: Alignment.bottomRight,
-                        colors:
-                            isDark
-                                ? [
-                                  AppColors.darkBorder,
-                                  AppColors.darkScaffold2,
-                                ]
-                                : [Colors.white, AppColors.lightScaffold2],
+                  child: Row(
+                    children: [
+                      Text(
+                        'Gradual Fade In',
+                        style: TextStyle(color: color, fontFamily: 'Poppins'),
                       ),
-                      boxShadow:
-                          isDark
-                              ? [
-                                BoxShadow(
-                                  offset: const Offset(-5, -5),
-                                  blurRadius: 20,
-                                  color: AppColors.darkGrey.withValues(
-                                    alpha: 0.35,
-                                  ),
-                                ),
-                                BoxShadow(
-                                  offset: const Offset(13, 14),
-                                  blurRadius: 12,
-                                  spreadRadius: -6,
-                                  color: AppColors.shadowDark.withValues(
-                                    alpha: 0.70,
-                                  ),
-                                ),
-                              ]
-                              : [
-                                BoxShadow(
-                                  offset: const Offset(-5, -5),
-                                  blurRadius: 20,
-                                  color: Colors.white.withValues(alpha: 0.53),
-                                ),
-                                BoxShadow(
-                                  offset: const Offset(13, 14),
-                                  blurRadius: 12,
-                                  spreadRadius: -6,
-                                  color: AppColors.shadowLight.withValues(
-                                    alpha: 0.57,
-                                  ),
-                                ),
-                              ],
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(1),
-                      child: SizedBox(
-                        height: 74,
-                        width: double.infinity,
-                        child: DecoratedBox(
-                          decoration: BoxDecoration(
-                            borderRadius: BorderRadius.circular(20),
-                            gradient: LinearGradient(
-                              begin: Alignment.topLeft,
-                              end: Alignment.bottomRight,
-                              colors:
-                                  isDark
-                                      ? [
-                                        AppColors.darkClock1,
-                                        AppColors.darkScaffold1,
-                                      ]
-                                      : [
-                                        AppColors.lightScaffold1,
-                                        AppColors.lightGradient2,
-                                      ],
-                            ),
-                          ),
-                          child: Padding(
-                            padding: const EdgeInsets.symmetric(horizontal: 18),
-                            child: Row(
-                              children: [
-                                Text(
-                                  'Gradual Fade In',
-                                  style: TextStyle(
-                                    color: color,
-                                    fontFamily: 'Poppins',
-                                  ),
-                                ),
-                                const Spacer(),
-                                GradientSwitch(
-                                  value: state.fadeInAlarm,
-                                  onChanged: (v) async {
-                                    final settingsCubit =
-                                        context.read<SettingsCubit>();
-                                    final alarmCubit =
-                                        context.read<AlarmCubit>();
-                                    await settingsCubit.setFadeInAlarm(v);
-                                    await alarmCubit.updateVolumeSettingsForAll(
-                                      fadeIn: v,
-                                      volume: state.alarmVolume,
-                                    );
-                                  },
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
+                      const Spacer(),
+                      GradientSwitch(
+                        value: state.fadeInAlarm,
+                        onChanged: (v) async {
+                          final settingsCubit = context.read<SettingsCubit>();
+                          final alarmCubit = context.read<AlarmCubit>();
+                          await settingsCubit.setFadeInAlarm(v);
+                          await alarmCubit.updateVolumeSettingsForAll(
+                            fadeIn: v,
+                            volume: state.alarmVolume,
+                          );
+                        },
                       ),
-                    ),
+                    ],
                   ),
                 ),
                 const SizedBox(height: 23),
@@ -465,234 +213,70 @@ class SettingsScreen extends StatelessWidget {
                         );
                       });
                     }
-                    return DecoratedBox(
-                      decoration: BoxDecoration(
-                        borderRadius: BorderRadius.circular(20),
-                        gradient: LinearGradient(
-                          begin: Alignment.topLeft,
-                          end: Alignment.bottomRight,
-                          colors:
-                              isDark
-                                  ? [
-                                    AppColors.darkBorder,
-                                    AppColors.darkScaffold2,
-                                  ]
-                                  : [Colors.white, AppColors.lightScaffold2],
-                        ),
-                        boxShadow:
-                            isDark
-                                ? [
-                                  BoxShadow(
-                                    offset: const Offset(-5, -5),
-                                    blurRadius: 20,
-                                    color: AppColors.darkGrey.withValues(
-                                      alpha: 0.35,
-                                    ),
-                                  ),
-                                  BoxShadow(
-                                    offset: const Offset(13, 14),
-                                    blurRadius: 12,
-                                    spreadRadius: -6,
-                                    color: AppColors.shadowDark.withValues(
-                                      alpha: 0.70,
-                                    ),
-                                  ),
-                                ]
-                                : [
-                                  BoxShadow(
-                                    offset: const Offset(-5, -5),
-                                    blurRadius: 20,
-                                    color: Colors.white.withValues(alpha: 0.53),
-                                  ),
-                                  BoxShadow(
-                                    offset: const Offset(13, 14),
-                                    blurRadius: 12,
-                                    spreadRadius: -6,
-                                    color: AppColors.shadowLight.withValues(
-                                      alpha: 0.57,
-                                    ),
-                                  ),
-                                ],
-                      ),
-                      child: Padding(
-                        padding: const EdgeInsets.all(1),
-                        child: SizedBox(
-                          height: 74,
-                          width: double.infinity,
-                          child: DecoratedBox(
-                            decoration: BoxDecoration(
-                              borderRadius: BorderRadius.circular(20),
-                              gradient: LinearGradient(
-                                begin: Alignment.topLeft,
-                                end: Alignment.bottomRight,
-                                colors:
-                                    isDark
-                                        ? [
-                                          AppColors.darkClock1,
-                                          AppColors.darkScaffold1,
-                                        ]
-                                        : [
-                                          AppColors.lightScaffold1,
-                                          AppColors.lightGradient2,
-                                        ],
-                              ),
-                            ),
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(
-                                horizontal: 18,
-                              ),
-                              child: Row(
-                                children: [
-                                  Text(
-                                    'Alarm Sound',
-                                    style: TextStyle(
-                                      color: color,
-                                      fontFamily: 'Poppins',
-                                    ),
-                                  ),
-                                  const SizedBox(width: 20),
-                                  Expanded(
-                                    child: DropdownButton<String>(
-                                      value: dropdownValue,
-                                      underline: const SizedBox(),
-                                      enableFeedback: true,
-                                      isExpanded: true,
-                                      dropdownColor:
-                                          isDark
-                                              ? AppColors.darkScaffold1
-                                              : Colors.white,
-                                      items: items,
-                                      onChanged: (v) async {
-                                        if (v == null) return;
-                                        if (v == '__add__') {
-                                          await _pickAndAddAudio(context);
-                                        } else {
-                                          final settingsCubit =
-                                              context.read<SettingsCubit>();
-                                          final alarmCubit =
-                                              context.read<AlarmCubit>();
-                                          await settingsCubit.setAlarmAudioPath(
-                                            v,
-                                          );
-                                          await alarmCubit
-                                              .updateAudioPathForAll(v);
-                                        }
-                                      },
-                                    ),
-                                  ),
-                                ],
-                              ),
+                    return SettingsTile(
+                      child: Row(
+                        children: [
+                          Text(
+                            'Alarm Sound',
+                            style: TextStyle(color: color, fontFamily: 'Poppins'),
+                          ),
+                          const SizedBox(width: 20),
+                          Expanded(
+                            child: DropdownButton<String>(
+                              value: dropdownValue,
+                              underline: const SizedBox(),
+                              enableFeedback: true,
+                              isExpanded: true,
+                              dropdownColor:
+                                  isDark ? AppColors.darkScaffold1 : Colors.white,
+                              items: items,
+                              onChanged: (v) async {
+                                if (v == null) return;
+                                if (v == '__add__') {
+                                  await _pickAndAddAudio(context);
+                                } else {
+                                  final settingsCubit =
+                                      context.read<SettingsCubit>();
+                                  final alarmCubit = context.read<AlarmCubit>();
+                                  await settingsCubit.setAlarmAudioPath(v);
+                                  await alarmCubit.updateAudioPathForAll(v);
+                                }
+                              },
                             ),
                           ),
-                        ),
+                        ],
                       ),
                     );
                   },
                 ),
                 const SizedBox(height: 23),
-                DecoratedBox(
-                  decoration: BoxDecoration(
-                    borderRadius: BorderRadius.circular(20),
-                    gradient: LinearGradient(
-                      begin: Alignment.topLeft,
-                      end: Alignment.bottomRight,
-                      colors:
-                          isDark
-                              ? [AppColors.darkBorder, AppColors.darkScaffold2]
-                              : [Colors.white, AppColors.lightScaffold2],
-                    ),
-                    boxShadow:
-                        isDark
-                            ? [
-                              BoxShadow(
-                                offset: const Offset(-5, -5),
-                                blurRadius: 20,
-                                color: AppColors.darkGrey.withValues(
-                                  alpha: 0.35,
-                                ),
-                              ),
-                              BoxShadow(
-                                offset: const Offset(13, 14),
-                                blurRadius: 12,
-                                spreadRadius: -6,
-                                color: AppColors.shadowDark.withValues(
-                                  alpha: 0.70,
-                                ),
-                              ),
-                            ]
-                            : [
-                              BoxShadow(
-                                offset: const Offset(-5, -5),
-                                blurRadius: 20,
-                                color: Colors.white.withValues(alpha: 0.53),
-                              ),
-                              BoxShadow(
-                                offset: const Offset(13, 14),
-                                blurRadius: 12,
-                                spreadRadius: -6,
-                                color: AppColors.shadowLight.withValues(
-                                  alpha: 0.57,
-                                ),
-                              ),
-                            ],
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.all(1),
-                    child: SizedBox(
-                      height: 74,
-                      width: double.infinity,
-                      child: DecoratedBox(
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(20),
-                          gradient: LinearGradient(
-                            begin: Alignment.topLeft,
-                            end: Alignment.bottomRight,
-                            colors:
-                                isDark
-                                    ? [
-                                      AppColors.darkClock1,
-                                      AppColors.darkScaffold1,
-                                    ]
-                                    : [
-                                      AppColors.lightScaffold1,
-                                      AppColors.lightGradient2,
-                                    ],
-                          ),
-                        ),
-                        child: Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 18),
-                          child: Row(
-                            children: [
-                              Icon(
-                                state.alarmVolume > 0.7
-                                    ? Icons.volume_up_rounded
-                                    : state.alarmVolume > 0.1
-                                    ? Icons.volume_down_rounded
-                                    : Icons.volume_mute_rounded,
-                                color: color,
-                              ),
-                              const SizedBox(width: 10),
-                              Expanded(
-                                child: GradientSlider(
-                                  value: state.alarmVolume,
-                                  onChanged: (v) async {
-                                    final settingsCubit =
-                                        context.read<SettingsCubit>();
-                                    final alarmCubit =
-                                        context.read<AlarmCubit>();
-                                    await settingsCubit.setAlarmVolume(v);
-                                    await alarmCubit.updateVolumeSettingsForAll(
-                                      fadeIn: state.fadeInAlarm,
-                                      volume: v,
-                                    );
-                                  },
-                                ),
-                              ),
-                            ],
-                          ),
+                SettingsTile(
+                  child: Row(
+                    children: [
+                      Icon(
+                        state.alarmVolume > 0.7
+                            ? Icons.volume_up_rounded
+                            : state.alarmVolume > 0.1
+                                ? Icons.volume_down_rounded
+                                : Icons.volume_mute_rounded,
+                        color: color,
+                      ),
+                      const SizedBox(width: 10),
+                      Expanded(
+                        child: GradientSlider(
+                          value: state.alarmVolume,
+                          onChanged: (v) async {
+                            final settingsCubit = context.read<SettingsCubit>();
+                            final alarmCubit = context.read<AlarmCubit>();
+                            await settingsCubit.setAlarmVolume(v);
+                            await alarmCubit.updateVolumeSettingsForAll(
+                              fadeIn: state.fadeInAlarm,
+                              volume: v,
+                            );
+                          },
                         ),
                       ),
-                    ),
+                    ],
                   ),
                 ),
               ],

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -93,8 +93,10 @@ class SettingsScreen extends StatelessWidget {
                 ),
                 const SizedBox(height: 23),
                 SettingsTile(
-                  onTap: () =>
-                      context.read<SettingsCubit>().setUse24HourFormat(!state.use24HourFormat),
+                  onTap:
+                      () => context.read<SettingsCubit>().setUse24HourFormat(
+                        !state.use24HourFormat,
+                      ),
                   child: Row(
                     children: [
                       Text(
@@ -104,9 +106,10 @@ class SettingsScreen extends StatelessWidget {
                       const Spacer(),
                       GradientSwitch(
                         value: state.use24HourFormat,
-                        onChanged: (v) => context
-                            .read<SettingsCubit>()
-                            .setUse24HourFormat(v),
+                        onChanged:
+                            (v) => context
+                                .read<SettingsCubit>()
+                                .setUse24HourFormat(v),
                       ),
                     ],
                   ),
@@ -189,7 +192,7 @@ class SettingsScreen extends StatelessWidget {
                       ),
                       const DropdownMenuItem(
                         value: '__add__',
-                        child: Text('Add Alarm'),
+                        child: Text('Add Sound'),
                       ),
                     ];
                     final values =
@@ -218,7 +221,10 @@ class SettingsScreen extends StatelessWidget {
                         children: [
                           Text(
                             'Alarm Sound',
-                            style: TextStyle(color: color, fontFamily: 'Poppins'),
+                            style: TextStyle(
+                              color: color,
+                              fontFamily: 'Poppins',
+                            ),
                           ),
                           const SizedBox(width: 20),
                           Expanded(
@@ -228,7 +234,9 @@ class SettingsScreen extends StatelessWidget {
                               enableFeedback: true,
                               isExpanded: true,
                               dropdownColor:
-                                  isDark ? AppColors.darkScaffold1 : Colors.white,
+                                  isDark
+                                      ? AppColors.darkScaffold1
+                                      : Colors.white,
                               items: items,
                               onChanged: (v) async {
                                 if (v == null) return;
@@ -257,8 +265,8 @@ class SettingsScreen extends StatelessWidget {
                         state.alarmVolume > 0.7
                             ? Icons.volume_up_rounded
                             : state.alarmVolume > 0.1
-                                ? Icons.volume_down_rounded
-                                : Icons.volume_mute_rounded,
+                            ? Icons.volume_down_rounded
+                            : Icons.volume_mute_rounded,
                         color: color,
                       ),
                       const SizedBox(width: 10),

--- a/lib/widgets/settings_tile.dart
+++ b/lib/widgets/settings_tile.dart
@@ -1,0 +1,84 @@
+import 'package:awake/extensions/context_extensions.dart';
+import 'package:awake/theme/app_colors.dart';
+import 'package:flutter/material.dart';
+
+class SettingsTile extends StatelessWidget {
+  final Widget child;
+  final VoidCallback? onTap;
+
+  const SettingsTile({super.key, required this.child, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isDark = context.isDarkMode;
+    final outerColors = isDark
+        ? [AppColors.darkBorder, AppColors.darkScaffold2]
+        : [Colors.white, AppColors.lightScaffold2];
+    final innerColors = isDark
+        ? [AppColors.darkClock1, AppColors.darkScaffold1]
+        : [AppColors.lightScaffold1, AppColors.lightGradient2];
+    final boxShadows = isDark
+        ? [
+            BoxShadow(
+              offset: const Offset(-5, -5),
+              blurRadius: 20,
+              color: AppColors.darkGrey.withValues(alpha: 0.35),
+            ),
+            BoxShadow(
+              offset: const Offset(13, 14),
+              blurRadius: 12,
+              spreadRadius: -6,
+              color: AppColors.shadowDark.withValues(alpha: 0.70),
+            ),
+          ]
+        : [
+            BoxShadow(
+              offset: const Offset(-5, -5),
+              blurRadius: 20,
+              color: Colors.white.withValues(alpha: 0.53),
+            ),
+            BoxShadow(
+              offset: const Offset(13, 14),
+              blurRadius: 12,
+              spreadRadius: -6,
+              color: AppColors.shadowLight.withValues(alpha: 0.57),
+            ),
+          ];
+
+    return GestureDetector(
+      onTap: onTap,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(20),
+          gradient: LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: outerColors,
+          ),
+          boxShadow: boxShadows,
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(1),
+          child: SizedBox(
+            height: 74,
+            width: double.infinity,
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(20),
+                gradient: LinearGradient(
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                  colors: innerColors,
+                ),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 18),
+                child: child,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/settings_tile.dart
+++ b/lib/widgets/settings_tile.dart
@@ -11,69 +11,76 @@ class SettingsTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final bool isDark = context.isDarkMode;
-    final outerColors = isDark
-        ? [AppColors.darkBorder, AppColors.darkScaffold2]
-        : [Colors.white, AppColors.lightScaffold2];
-    final innerColors = isDark
-        ? [AppColors.darkClock1, AppColors.darkScaffold1]
-        : [AppColors.lightScaffold1, AppColors.lightGradient2];
-    final boxShadows = isDark
-        ? [
-            BoxShadow(
-              offset: const Offset(-5, -5),
-              blurRadius: 20,
-              color: AppColors.darkGrey.withValues(alpha: 0.35),
-            ),
-            BoxShadow(
-              offset: const Offset(13, 14),
-              blurRadius: 12,
-              spreadRadius: -6,
-              color: AppColors.shadowDark.withValues(alpha: 0.70),
-            ),
-          ]
-        : [
-            BoxShadow(
-              offset: const Offset(-5, -5),
-              blurRadius: 20,
-              color: Colors.white.withValues(alpha: 0.53),
-            ),
-            BoxShadow(
-              offset: const Offset(13, 14),
-              blurRadius: 12,
-              spreadRadius: -6,
-              color: AppColors.shadowLight.withValues(alpha: 0.57),
-            ),
-          ];
-
-    return GestureDetector(
-      onTap: onTap,
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(20),
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors: outerColors,
-          ),
-          boxShadow: boxShadows,
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(1),
-          child: SizedBox(
-            height: 74,
-            width: double.infinity,
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(20),
-                gradient: LinearGradient(
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
-                  colors: innerColors,
-                ),
+    final outerColors =
+        isDark
+            ? [AppColors.darkBorder, AppColors.darkScaffold2]
+            : [Colors.white, AppColors.lightScaffold2];
+    final innerColors =
+        isDark
+            ? [AppColors.darkClock1, AppColors.darkScaffold1]
+            : [AppColors.lightScaffold1, AppColors.lightGradient2];
+    final boxShadows =
+        isDark
+            ? [
+              BoxShadow(
+                offset: const Offset(-5, -5),
+                blurRadius: 20,
+                color: AppColors.darkGrey.withValues(alpha: 0.35),
               ),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 18),
-                child: child,
+              BoxShadow(
+                offset: const Offset(13, 14),
+                blurRadius: 12,
+                spreadRadius: -6,
+                color: AppColors.shadowDark.withValues(alpha: 0.70),
+              ),
+            ]
+            : [
+              BoxShadow(
+                offset: const Offset(-5, -5),
+                blurRadius: 20,
+                color: Colors.white.withValues(alpha: 0.53),
+              ),
+              BoxShadow(
+                offset: const Offset(13, 14),
+                blurRadius: 12,
+                spreadRadius: -6,
+                color: AppColors.shadowLight.withValues(alpha: 0.57),
+              ),
+            ];
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: outerColors,
+        ),
+        boxShadow: boxShadows,
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(1),
+        child: SizedBox(
+          height: 74,
+          width: double.infinity,
+          child: DecoratedBox(
+            decoration: BoxDecoration(
+              borderRadius: const BorderRadius.all(Radius.circular(20)),
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: innerColors,
+              ),
+            ),
+            child: Material(
+              type: MaterialType.transparency,
+              child: InkWell(
+                onTap: onTap,
+                borderRadius: const BorderRadius.all(Radius.circular(20)),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 18),
+                  child: child,
+                ),
               ),
             ),
           ),

--- a/lib/widgets/theme_list_tile.dart
+++ b/lib/widgets/theme_list_tile.dart
@@ -1,5 +1,6 @@
 import 'package:awake/extensions/context_extensions.dart';
 import 'package:awake/theme/app_colors.dart';
+import 'package:awake/widgets/settings_tile.dart';
 import 'package:flutter/material.dart';
 
 class ThemeListTile extends StatelessWidget {
@@ -35,84 +36,14 @@ class ThemeListTile extends StatelessWidget {
     final bool isDark = context.isDarkMode;
     final color =
         isDark ? AppColors.darkBackgroundText : AppColors.lightBackgroundText;
-    return GestureDetector(
+    return SettingsTile(
       onTap: () => onChanged(_nextMode(mode)),
-      child: DecoratedBox(
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(20),
-          gradient: LinearGradient(
-            begin: Alignment.topLeft,
-            end: Alignment.bottomRight,
-            colors:
-                isDark
-                    ? [AppColors.darkBorder, AppColors.darkScaffold2]
-                    : [Colors.white, AppColors.lightScaffold2],
-          ),
-          boxShadow:
-              isDark
-                  ? [
-                    BoxShadow(
-                      offset: const Offset(-5, -5),
-                      blurRadius: 20,
-                      color: AppColors.darkGrey.withValues(alpha: 0.35),
-                    ),
-                    BoxShadow(
-                      offset: const Offset(13, 14),
-                      blurRadius: 12,
-                      spreadRadius: -6,
-                      color: AppColors.shadowDark.withValues(alpha: 0.70),
-                    ),
-                  ]
-                  : [
-                    BoxShadow(
-                      offset: const Offset(-5, -5),
-                      blurRadius: 20,
-                      color: Colors.white.withValues(alpha: 0.53),
-                    ),
-                    BoxShadow(
-                      offset: const Offset(13, 14),
-                      blurRadius: 12,
-                      spreadRadius: -6,
-                      color: AppColors.shadowLight.withValues(alpha: 0.57),
-                    ),
-                  ],
-        ),
-        child: Padding(
-          padding: const EdgeInsets.all(1),
-          child: SizedBox(
-            height: 74,
-            width: double.infinity,
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                borderRadius: BorderRadius.circular(20),
-                gradient: LinearGradient(
-                  begin: Alignment.topLeft,
-                  end: Alignment.bottomRight,
-                  colors:
-                      isDark
-                          ? [AppColors.darkClock1, AppColors.darkScaffold1]
-                          : [
-                            AppColors.lightScaffold1,
-                            AppColors.lightGradient2,
-                          ],
-                ),
-              ),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 18),
-                child: Row(
-                  children: [
-                    Text(
-                      'Theme',
-                      style: TextStyle(color: color, fontFamily: 'Poppins'),
-                    ),
-                    const Spacer(),
-                    Icon(_iconForMode(mode), color: color),
-                  ],
-                ),
-              ),
-            ),
-          ),
-        ),
+      child: Row(
+        children: [
+          Text('Theme', style: TextStyle(color: color, fontFamily: 'Poppins')),
+          const Spacer(),
+          Icon(_iconForMode(mode), color: color),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- introduce a `SettingsTile` widget for consistent styling
- refactor `ThemeListTile` to use `SettingsTile`
- simplify `SettingsScreen` by reusing `SettingsTile`

## Testing
- `dart format -o none --set-exit-if-changed .`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_686b21b00b5483248fe3db71688912b0