### PR TITLE
Add clear custom sounds option

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -259,7 +259,8 @@ class SettingsScreen extends StatelessWidget {
                         );
                       });
                     }
-                    return SettingsTile(
+
+                    final alarmSoundTile = SettingsTile(
                       child: Row(
                         children: [
                           Text(
@@ -297,6 +298,36 @@ class SettingsScreen extends StatelessWidget {
                           ),
                         ],
                       ),
+                    );
+
+                    if (files.isEmpty) {
+                      return alarmSoundTile;
+                    }
+
+                    return Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        alarmSoundTile,
+                        const SizedBox(height: 23),
+                        SettingsTile(
+                          onTap: () async {
+                            await context
+                                .read<CustomSoundsCubit>()
+                                .clearSounds();
+                          },
+                          child: Row(
+                            children: [
+                              Text(
+                                'Clear Custom Sounds',
+                                style: TextStyle(
+                                  color: color,
+                                  fontFamily: 'Poppins',
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
                     );
                   },
                 ),

--- a/lib/services/custom_sounds_cubit.dart
+++ b/lib/services/custom_sounds_cubit.dart
@@ -32,4 +32,16 @@ class CustomSoundsCubit extends Cubit<List<String>> {
     await _loadSounds();
     return newPath;
   }
+
+  Future<void> clearSounds() async {
+    final dir = await _customDir;
+    if (await dir.exists()) {
+      await for (final entity in dir.list()) {
+        if (entity is File) {
+          await entity.delete();
+        }
+      }
+    }
+    await _loadSounds();
+  }
 }


### PR DESCRIPTION
## Summary
- add `clearSounds` method to `CustomSoundsCubit`
- show an option in settings to clear custom sounds when any are available

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_686b388ffdcc8324885440a7d2a926b2