### PR TITLE
Store alarm titles

### DIFF
--- a/lib/models/alarm_db_entry.dart
+++ b/lib/models/alarm_db_entry.dart
@@ -4,8 +4,14 @@ class AlarmDbEntry {
   final TimeOfDay time;
   final List<int> days;
   final bool enabled;
+  final String body;
 
-  AlarmDbEntry({required this.time, required this.days, this.enabled = true});
+  AlarmDbEntry({
+    required this.time,
+    required this.days,
+    this.enabled = true,
+    this.body = '',
+  });
 
   Map<String, dynamic> toMap() {
     final timeString = '${time.hour}:${time.minute}';
@@ -13,6 +19,7 @@ class AlarmDbEntry {
       'time': timeString,
       'days': days.join(','),
       'enabled': enabled ? 1 : 0,
+      'body': body,
     };
   }
 
@@ -26,10 +33,12 @@ class AlarmDbEntry {
             ? <int>[]
             : daysString.split(',').map(int.parse).toList();
     final enabled = (map['enabled'] as int?) ?? 1;
+    final body = map['body'] as String? ?? '';
     return AlarmDbEntry(
       time: TimeOfDay(hour: hour, minute: minute),
       days: dayList,
       enabled: enabled == 1,
+      body: body,
     );
   }
 }

--- a/lib/models/alarm_model.dart
+++ b/lib/models/alarm_model.dart
@@ -6,12 +6,14 @@ class AlarmModel {
   final TimeOfDay timeOfDay;
   final List<int> days;
   final bool enabled;
+  final String body;
   final List<AlarmSettings> alarmSettings;
 
   AlarmModel({
     required this.timeOfDay,
     required this.days,
     this.enabled = true,
+    this.body = '',
     this.alarmSettings = const [],
   });
 
@@ -21,14 +23,16 @@ class AlarmModel {
         other.timeOfDay == timeOfDay &&
         listEquals(other.days, days) &&
         other.enabled == enabled &&
+        other.body == body &&
         listEquals(other.alarmSettings, alarmSettings);
   }
 
   @override
-  int get hashCode => Object.hash(timeOfDay, days, enabled, alarmSettings);
+  int get hashCode =>
+      Object.hash(timeOfDay, days, enabled, body, alarmSettings);
 
   @override
   String toString() {
-    return 'AlarmModel(timeOfDay: $timeOfDay, days: $days, enabled: $enabled, alarmSettings: $alarmSettings)';
+    return 'AlarmModel(timeOfDay: $timeOfDay, days: $days, enabled: $enabled, body: $body, alarmSettings: $alarmSettings)';
   }
 }

--- a/lib/screens/add_alarm_screen.dart
+++ b/lib/screens/add_alarm_screen.dart
@@ -51,7 +51,7 @@ class _AddAlarmScreenState extends State<AddAlarmScreen> {
     await context.read<AlarmCubit>().setPeriodicAlarms(
       timeOfDay: _selectedTime,
       days: _selectedDays.toList(),
-      body: title.isEmpty ? 'Time to Wake Up' : title,
+      body: title,
     );
     if (mounted) Navigator.pop(context);
   }

--- a/lib/services/alarm_cubit.dart
+++ b/lib/services/alarm_cubit.dart
@@ -28,7 +28,7 @@ class AlarmCubit extends Cubit<List<AlarmModel>> {
           entry.time,
           entry.days,
           alarmSettingsSet,
-          body: 'Time to Wake Up',
+          body: entry.body,
         );
       } else {
         alarmSettingsSet.putIfAbsent(entry.time, () => []);
@@ -43,6 +43,7 @@ class AlarmCubit extends Cubit<List<AlarmModel>> {
           timeOfDay: entry.time,
           days: entry.days,
           enabled: entry.enabled,
+          body: entry.body,
           alarmSettings: alarms,
         ),
       );
@@ -165,14 +166,19 @@ class AlarmCubit extends Cubit<List<AlarmModel>> {
       DateTime.saturday,
       DateTime.sunday,
     ],
-    String body = 'Time to Wake Up',
+    String body = '',
   }) async {
     final existingEntry = await AlarmDatabase.getAlarm(timeOfDay);
     final updatedDays = {...(existingEntry?.days ?? []), ...days}.toList();
     final enabled = existingEntry?.enabled ?? true;
 
     await AlarmDatabase.insertOrUpdate(
-      AlarmDbEntry(time: timeOfDay, days: updatedDays, enabled: enabled),
+      AlarmDbEntry(
+        time: timeOfDay,
+        days: updatedDays,
+        enabled: enabled,
+        body: body,
+      ),
     );
 
     if (enabled) {
@@ -182,12 +188,7 @@ class AlarmCubit extends Cubit<List<AlarmModel>> {
         final alarmTime = TimeOfDay.fromDateTime(alarm.dateTime);
         current.putIfAbsent(alarmTime, () => []).add(alarm);
       }
-      await _ensureUpcomingWeek(
-        timeOfDay,
-        updatedDays,
-        current,
-        body: 'Time to Wake Up',
-      );
+      await _ensureUpcomingWeek(timeOfDay, updatedDays, current, body: body);
       await _loadAlarms(presetAlarms: current.values.expand((e) => e).toList());
     } else {
       await _loadAlarms();
@@ -210,7 +211,12 @@ class AlarmCubit extends Cubit<List<AlarmModel>> {
     final entry = await AlarmDatabase.getAlarm(timeOfDay);
     if (entry == null) return;
     await AlarmDatabase.insertOrUpdate(
-      AlarmDbEntry(time: timeOfDay, days: entry.days, enabled: enabled),
+      AlarmDbEntry(
+        time: timeOfDay,
+        days: entry.days,
+        enabled: enabled,
+        body: entry.body,
+      ),
     );
 
     if (!enabled) {
@@ -233,7 +239,12 @@ class AlarmCubit extends Cubit<List<AlarmModel>> {
     final entry = await AlarmDatabase.getAlarm(timeOfDay);
     final bool enabled = days.isNotEmpty && (entry?.enabled ?? true);
     await AlarmDatabase.insertOrUpdate(
-      AlarmDbEntry(time: timeOfDay, days: days, enabled: enabled),
+      AlarmDbEntry(
+        time: timeOfDay,
+        days: days,
+        enabled: enabled,
+        body: entry?.body ?? '',
+      ),
     );
 
     final existing = await Alarm.getAlarms();
@@ -252,7 +263,7 @@ class AlarmCubit extends Cubit<List<AlarmModel>> {
         timeOfDay,
         days,
         current,
-        body: 'Time to Wake Up',
+        body: entry?.body ?? '',
       );
     }
 

--- a/lib/services/alarm_database.dart
+++ b/lib/services/alarm_database.dart
@@ -10,16 +10,21 @@ class AlarmDatabase {
     final path = '$dir/alarms.db';
     _db = await openDatabase(
       path,
-      version: 2,
+      version: 3,
       onCreate: (db, version) async {
         await db.execute(
-          'CREATE TABLE alarms(time TEXT PRIMARY KEY, days TEXT, enabled INTEGER)',
+          'CREATE TABLE alarms(time TEXT PRIMARY KEY, days TEXT, enabled INTEGER, body TEXT)',
         );
       },
       onUpgrade: (db, oldVersion, newVersion) async {
-        if (oldVersion == 1 && newVersion == 2) {
+        if (oldVersion < 2 && newVersion >= 2) {
           await db.execute(
             'ALTER TABLE alarms ADD COLUMN enabled INTEGER DEFAULT 1',
+          );
+        }
+        if (oldVersion < 3 && newVersion >= 3) {
+          await db.execute(
+            "ALTER TABLE alarms ADD COLUMN body TEXT DEFAULT ''",
           );
         }
       },


### PR DESCRIPTION
## Summary
- support storing custom alarm body text
- wire add alarm screen to pass the text
- preserve alarm body when updating alarms
- migrate alarm database to include body field

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_686c8dfd732c83248720e1d2d1cecbdc