### PR TITLE
Edit alarm via dedicated screen

### DIFF
--- a/lib/widgets/alarm_tile.dart
+++ b/lib/widgets/alarm_tile.dart
@@ -1,4 +1,5 @@
 import 'package:awake/models/alarm_model.dart';
+import 'package:awake/screens/add_alarm_screen.dart';
 import 'package:awake/services/settings_cubit.dart';
 import 'package:awake/theme/app_colors.dart';
 import 'package:awake/widgets/gradient_switch.dart';
@@ -69,137 +70,11 @@ class _AlarmTileState extends State<AlarmTile> {
     );
   }
 
-  Widget _daySelector(
-    Set<int> days,
-    bool isDark,
-    ValueChanged<Set<int>> onChanged,
-  ) {
-    const dayLabels = ['M', 'T', 'W', 'T', 'F', 'S', 'Su'];
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        for (int i = 0; i < dayLabels.length; i++)
-          GestureDetector(
-            onTap: () {
-              final newDays = <int>{...days};
-              if (newDays.contains(i + 1)) {
-                newDays.remove(i + 1);
-              } else {
-                newDays.add(i + 1);
-              }
-              onChanged(newDays);
-            },
-            child: SizedBox(
-              height: 32,
-              width: 32,
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color:
-                      days.contains(i + 1)
-                          ? AppColors.primary
-                          : Colors.transparent,
-                  border:
-                      days.contains(i + 1)
-                          ? null
-                          : Border.all(
-                            color:
-                                isDark
-                                    ? AppColors.darkBorder
-                                    : AppColors.lightBlueGrey,
-                          ),
-                ),
-                child: Center(
-                  child: Text(
-                    dayLabels[i],
-                    style: TextStyle(
-                      fontFamily: 'Poppins',
-                      color:
-                          days.contains(i + 1)
-                              ? Colors.white
-                              : isDark
-                              ? AppColors.darkBackgroundText
-                              : AppColors.lightBackgroundText,
-                    ),
-                  ),
-                ),
-              ),
-            ),
-          ),
-      ],
-    );
-  }
-
   Future<void> _showEditDialog() async {
-    final bool isDark = Theme.brightnessOf(context) == Brightness.dark;
-    final bool use24h = context.read<SettingsCubit>().state.use24HourFormat;
-    await showDialog<void>(
-      context: context,
-      builder: (context) {
-        return StatefulBuilder(
-          builder: (context, setStateDialog) {
-            return AlertDialog(
-              backgroundColor:
-                  isDark ? AppColors.darkScaffold1 : AppColors.lightScaffold1,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(20),
-              ),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Row(
-                    children: [
-                      Text(
-                        MaterialLocalizations.of(context).formatTimeOfDay(
-                          widget.alarmModel.timeOfDay,
-                          alwaysUse24HourFormat: use24h,
-                        ),
-                        style: TextStyle(
-                          color:
-                              isDark
-                                  ? AppColors.darkBackgroundText
-                                  : AppColors.lightBackgroundText,
-                          fontFamily: 'Poppins',
-                          fontSize: 34,
-                          fontWeight: FontWeight.w500,
-                        ),
-                      ),
-                      const Spacer(),
-                      GradientSwitch(
-                        value: _enabled,
-                        onChanged: (v) {
-                          setState(() => _enabled = v);
-                          setStateDialog(() {});
-                          widget.onEnabledChanged(v);
-                        },
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: 20),
-                  _daySelector(_selectedDays, isDark, (d) {
-                    setState(() => _selectedDays = d);
-                    if (_selectedDays.isEmpty && _enabled) {
-                      setState(() => _enabled = false);
-                      widget.onEnabledChanged(false);
-                    }
-                    setStateDialog(() {});
-                    widget.onDaysChanged(_selectedDays.toList());
-                  }),
-                  const SizedBox(height: 20),
-                  TextButton.icon(
-                    onPressed: () {
-                      Navigator.of(context).pop();
-                      widget.onDelete();
-                    },
-                    icon: const Icon(Icons.delete),
-                    label: const Text('Delete Alarm'),
-                  ),
-                ],
-              ),
-            );
-          },
-        );
-      },
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (context) => AddAlarmScreen(alarmModel: widget.alarmModel),
+      ),
     );
   }
 


### PR DESCRIPTION
## Summary
- open AddAlarmScreen when tapping an alarm tile
- allow AddAlarmScreen to edit existing alarms

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_686c91bb3ca08324a39dce10533d661c