### PR TITLE
Require camera permission before enabling QR screen

### DIFF
--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:awake/extensions/context_extensions.dart';
 import 'package:awake/models/alarm_screen_type.dart';
 import 'package:awake/services/alarm_cubit.dart';
+import 'package:awake/services/alarm_permissions.dart';
 import 'package:awake/services/custom_sounds_cubit.dart';
 import 'package:awake/services/settings_cubit.dart';
 import 'package:awake/theme/app_colors.dart';
@@ -228,11 +229,27 @@ class SettingsScreen extends StatelessWidget {
                             ),
                           ],
                           onChanged: (v) async {
-                            if (v != null) {
-                              await context
-                                  .read<SettingsCubit>()
-                                  .setAlarmScreenType(v);
+                            if (v == null) return;
+                            if (v == AlarmScreenType.qr) {
+                              final granted =
+                                  await AlarmPermissions.checkCameraPermission();
+                              if (!granted) {
+                                if (context.mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(
+                                      content: Text(
+                                        'Camera permission is required for QR Code Scan',
+                                      ),
+                                    ),
+                                  );
+                                }
+                                return;
+                              }
                             }
+                            if (!context.mounted) return;
+                            await context
+                                .read<SettingsCubit>()
+                                .setAlarmScreenType(v);
                           },
                         ),
                       ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -46,7 +46,7 @@ class SettingsScreen extends StatelessWidget {
       type: FileType.image,
       bytes: byteData.buffer.asUint8List(),
     );
-    if (context.mounted) {
+    if (context.mounted && saveLocation != null) {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(SnackBar(content: Text('File saved to $saveLocation')));

--- a/lib/services/alarm_permissions.dart
+++ b/lib/services/alarm_permissions.dart
@@ -16,4 +16,12 @@ class AlarmPermissions {
       await Permission.scheduleExactAlarm.request();
     }
   }
+
+  static Future<bool> checkCameraPermission() async {
+    var status = await Permission.camera.status;
+    if (!status.isGranted) {
+      status = await Permission.camera.request();
+    }
+    return status.isGranted;
+  }
 }


### PR DESCRIPTION
## Summary
- add method for camera permissions
- request camera access before enabling QR code alarm screen

## Testing
- `flutter analyze`
- `flutter test` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d64b243a08324a4bcaee0b726186b