### PR TITLE
Display alarm titles on ringing screens

### DIFF
--- a/lib/screens/alarm_ringing_screen.dart
+++ b/lib/screens/alarm_ringing_screen.dart
@@ -34,6 +34,18 @@ class AlarmRingingScreen extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 Lottie.asset("assets/lottie/clock.json"),
+                const SizedBox(height: 20),
+                Text(
+                  alarmSettings.notificationSettings.body,
+                  style: TextStyle(
+                    color:
+                        isDark
+                            ? AppColors.darkBackgroundText
+                            : AppColors.lightBackgroundText,
+                    fontSize: 24,
+                    fontFamily: 'Poppins',
+                  ),
+                ),
                 const Spacer(),
                 GestureDetector(
                   onTap: () async {

--- a/lib/screens/math_alarm_screen.dart
+++ b/lib/screens/math_alarm_screen.dart
@@ -70,6 +70,18 @@ class _MathAlarmScreenState extends State<MathAlarmScreen> {
             child: Column(
               children: [
                 const Spacer(),
+                Text(
+                  widget.alarmSettings.notificationSettings.body,
+                  style: TextStyle(
+                    color:
+                        isDark
+                            ? AppColors.darkBackgroundText
+                            : AppColors.lightBackgroundText,
+                    fontSize: 24,
+                    fontFamily: 'Poppins',
+                  ),
+                ),
+                const SizedBox(height: 20),
                 Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [

--- a/lib/screens/qr_alarm_screen.dart
+++ b/lib/screens/qr_alarm_screen.dart
@@ -77,6 +77,18 @@ class _QrAlarmScreenState extends State<QrAlarmScreen> {
           child: Column(
             children: [
               const Spacer(),
+              Text(
+                widget.alarmSettings.notificationSettings.body,
+                style: TextStyle(
+                  color:
+                      isDark
+                          ? AppColors.darkBackgroundText
+                          : AppColors.lightBackgroundText,
+                  fontSize: 24,
+                  fontFamily: 'Poppins',
+                ),
+              ),
+              const SizedBox(height: 20),
               Expanded(
                 flex: 6,
                 child: MobileScanner(

--- a/lib/screens/shake_alarm_screen.dart
+++ b/lib/screens/shake_alarm_screen.dart
@@ -86,6 +86,18 @@ class _ShakeAlarmScreenState extends State<ShakeAlarmScreen> {
                 Lottie.asset("assets/lottie/phone_vibrate.json"),
                 const SizedBox(height: 20),
                 Text(
+                  widget.alarmSettings.notificationSettings.body,
+                  style: TextStyle(
+                    color:
+                        isDark
+                            ? AppColors.darkBackgroundText
+                            : AppColors.lightBackgroundText,
+                    fontSize: 24,
+                    fontFamily: 'Poppins',
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Text(
                   'Shake the phone!',
                   style: TextStyle(
                     color:


### PR DESCRIPTION
## Summary
- show alarm title on the default alarm screen
- display alarm title on math alarm screen
- show alarm title on QR alarm screen
- display alarm title on shake alarm screen

## Testing
- `dart analyze`

------
https://chatgpt.com/codex/tasks/task_e_686d675d10bc8324aee3649ff9cdbc36