### PR TITLE
Add tap challenge alarm screen

### DIFF
--- a/lib/models/alarm_screen_type.dart
+++ b/lib/models/alarm_screen_type.dart
@@ -1,1 +1,1 @@
-enum AlarmScreenType { ringing, math, shake, qr }
+enum AlarmScreenType { ringing, math, shake, qr, tap }

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -12,6 +12,7 @@ import 'package:awake/screens/math_alarm_screen.dart';
 import 'package:awake/screens/qr_alarm_screen.dart';
 import 'package:awake/screens/settings_screen.dart';
 import 'package:awake/screens/shake_alarm_screen.dart';
+import 'package:awake/screens/tap_alarm_screen.dart';
 import 'package:awake/services/alarm_cubit.dart';
 import 'package:awake/services/alarm_permissions.dart';
 import 'package:awake/services/settings_cubit.dart';
@@ -65,6 +66,8 @@ class _HomeState extends State<Home> {
       screen = ShakeAlarmScreen(alarmSettings: alarms.alarms.first);
     } else if (screenType == AlarmScreenType.qr) {
       screen = QrAlarmScreen(alarmSettings: alarms.alarms.first);
+    } else if (screenType == AlarmScreenType.tap) {
+      screen = TapAlarmScreen(alarmSettings: alarms.alarms.first);
     }
     await Navigator.push(
       context,

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -224,6 +224,10 @@ class SettingsScreen extends StatelessWidget {
                               child: Text('Shake to Stop'),
                             ),
                             DropdownMenuItem(
+                              value: AlarmScreenType.tap,
+                              child: Text('Tap Challenge'),
+                            ),
+                            DropdownMenuItem(
                               value: AlarmScreenType.qr,
                               child: Text('QR Code Scan'),
                             ),

--- a/lib/screens/tap_alarm_screen.dart
+++ b/lib/screens/tap_alarm_screen.dart
@@ -1,0 +1,105 @@
+import 'package:alarm/alarm.dart';
+import 'package:awake/extensions/context_extensions.dart';
+import 'package:awake/services/alarm_cubit.dart';
+import 'package:awake/theme/app_colors.dart';
+import 'package:awake/widgets/gradient_linear_progress_indicator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+class TapAlarmScreen extends StatefulWidget {
+  final AlarmSettings alarmSettings;
+
+  const TapAlarmScreen({super.key, required this.alarmSettings});
+
+  @override
+  State<TapAlarmScreen> createState() => _TapAlarmScreenState();
+}
+
+class _TapAlarmScreenState extends State<TapAlarmScreen> {
+  int _tapCount = 0;
+  static const int _requiredTaps = 50;
+
+  Future<void> _onTap() async {
+    setState(() => _tapCount++);
+    if (_tapCount >= _requiredTaps) {
+      await context.read<AlarmCubit>().stopAlarm(widget.alarmSettings.id);
+      if (mounted) {
+        Navigator.pop(context);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isDark = context.isDarkMode;
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        body: DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors:
+                  isDark
+                      ? [AppColors.darkScaffold1, AppColors.darkScaffold2]
+                      : [AppColors.lightScaffold1, AppColors.lightScaffold2],
+            ),
+          ),
+          child: GestureDetector(
+            behavior: HitTestBehavior.opaque,
+            onTap: _onTap,
+            child: Column(
+              children: [
+                const Spacer(),
+                Text(
+                  widget.alarmSettings.notificationSettings.body,
+                  style: TextStyle(
+                    color:
+                        isDark
+                            ? AppColors.darkBackgroundText
+                            : AppColors.lightBackgroundText,
+                    fontSize: 24,
+                    fontFamily: 'Poppins',
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  'Tap the screen!',
+                  style: TextStyle(
+                    color:
+                        isDark
+                            ? AppColors.darkBackgroundText
+                            : AppColors.lightBackgroundText,
+                    fontSize: 24,
+                    fontFamily: 'Poppins',
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  'Taps: \$_tapCount / \$_requiredTaps',
+                  style: TextStyle(
+                    color:
+                        isDark
+                            ? AppColors.darkBackgroundText
+                            : AppColors.lightBackgroundText,
+                    fontSize: 24,
+                    fontFamily: 'Poppins',
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 40),
+                  child: GradientLinearProgressIndicator(
+                    value: _tapCount / _requiredTaps,
+                  ),
+                ),
+                const Spacer(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new tap challenge mode for stopping an alarm
- integrate Tap Alarm screen into home and settings
- add `tap` value to alarm screen type enum

## Testing
- `flutter analyze`
- `flutter test` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d8e2f81cc8324bb673a0c70ae251b