### PR TITLE
Add blow alarm screen

### DIFF
--- a/lib/models/alarm_screen_type.dart
+++ b/lib/models/alarm_screen_type.dart
@@ -1,1 +1,1 @@
-enum AlarmScreenType { ringing, math, shake, qr }
+enum AlarmScreenType { ringing, math, shake, qr, blow }

--- a/lib/screens/blow_alarm_screen.dart
+++ b/lib/screens/blow_alarm_screen.dart
@@ -1,0 +1,122 @@
+import 'dart:async';
+
+import 'package:alarm/alarm.dart';
+import 'package:awake/extensions/context_extensions.dart';
+import 'package:awake/services/alarm_cubit.dart';
+import 'package:awake/theme/app_colors.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:noise_meter/noise_meter.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+class BlowAlarmScreen extends StatefulWidget {
+  final AlarmSettings alarmSettings;
+  const BlowAlarmScreen({super.key, required this.alarmSettings});
+
+  @override
+  State<BlowAlarmScreen> createState() => _BlowAlarmScreenState();
+}
+
+class _BlowAlarmScreenState extends State<BlowAlarmScreen> {
+  late final NoiseMeter _noiseMeter;
+  StreamSubscription<NoiseReading>? _subscription;
+  int _blowCount = 0;
+  static const int _requiredBlows = 3;
+  static const double _threshold = 80; // decibels
+
+  @override
+  void initState() {
+    super.initState();
+    _noiseMeter = NoiseMeter();
+    unawaited(_startListening());
+  }
+
+  Future<void> _startListening() async {
+    final status = await Permission.microphone.status;
+    if (status.isDenied) await Permission.microphone.request();
+    if (!mounted) return;
+    try {
+      _subscription = _noiseMeter.noise.listen(_onData);
+    } catch (_) {}
+  }
+
+  Future<void> _onData(NoiseReading reading) async {
+    if (reading.meanDecibel > _threshold) {
+      await _subscription?.cancel();
+      setState(() => _blowCount++);
+      if (_blowCount >= _requiredBlows) {
+        // ignore: use_build_context_synchronously
+        final cubit = context.read<AlarmCubit>();
+        await cubit.stopAlarm(widget.alarmSettings.id);
+        if (!mounted) return;
+        // ignore: use_build_context_synchronously
+        Navigator.pop(context);
+      } else {
+        await _startListening();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    unawaited(_subscription?.cancel());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isDark = context.isDarkMode;
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        body: DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: isDark
+                  ? [AppColors.darkScaffold1, AppColors.darkScaffold2]
+                  : [AppColors.lightScaffold1, AppColors.lightScaffold2],
+            ),
+          ),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Spacer(),
+              Icon(
+                Icons.mic,
+                color: isDark
+                    ? AppColors.darkBackgroundText
+                    : AppColors.lightBackgroundText,
+                size: 100,
+              ),
+              const SizedBox(height: 20),
+              Text(
+                widget.alarmSettings.notificationSettings.body,
+                style: TextStyle(
+                  color: isDark
+                      ? AppColors.darkBackgroundText
+                      : AppColors.lightBackgroundText,
+                  fontSize: 24,
+                  fontFamily: 'Poppins',
+                ),
+              ),
+              const SizedBox(height: 20),
+              Text(
+                'Blows: $_blowCount / $_requiredBlows',
+                style: TextStyle(
+                  color: isDark
+                      ? AppColors.darkBackgroundText
+                      : AppColors.lightBackgroundText,
+                  fontSize: 24,
+                  fontFamily: 'Poppins',
+                ),
+              ),
+              const Spacer(),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -8,6 +8,7 @@ import 'package:awake/models/alarm_model.dart';
 import 'package:awake/models/alarm_screen_type.dart';
 import 'package:awake/screens/add_alarm_screen.dart';
 import 'package:awake/screens/alarm_ringing_screen.dart';
+import 'package:awake/screens/blow_alarm_screen.dart';
 import 'package:awake/screens/math_alarm_screen.dart';
 import 'package:awake/screens/qr_alarm_screen.dart';
 import 'package:awake/screens/settings_screen.dart';
@@ -65,6 +66,8 @@ class _HomeState extends State<Home> {
       screen = ShakeAlarmScreen(alarmSettings: alarms.alarms.first);
     } else if (screenType == AlarmScreenType.qr) {
       screen = QrAlarmScreen(alarmSettings: alarms.alarms.first);
+    } else if (screenType == AlarmScreenType.blow) {
+      screen = BlowAlarmScreen(alarmSettings: alarms.alarms.first);
     }
     await Navigator.push(
       context,

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -227,6 +227,10 @@ class SettingsScreen extends StatelessWidget {
                               value: AlarmScreenType.qr,
                               child: Text('QR Code Scan'),
                             ),
+                            DropdownMenuItem(
+                              value: AlarmScreenType.blow,
+                              child: Text('Blow to Stop'),
+                            ),
                           ],
                           onChanged: (v) async {
                             if (v == null) return;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  audio_streamer:
+    dependency: transitive
+    description:
+      name: audio_streamer
+      sha256: f9084f3d4c98bd83ad5255a8b9250adcc81515de170efd7ef16a7663f8b8d95c
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   bloc:
     dependency: transitive
     description:
@@ -288,6 +296,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  noise_meter:
+    dependency: "direct main"
+    description:
+      name: noise_meter
+      sha256: "1eab67e5023c24c43757fa2b6b1b8bc43277e9cc6a7b0fb1c6f6537cc0e3116c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.0.2"
   path:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   flutter_inset_box_shadow_update: ^0.0.1
   lottie: ^3.3.1
   mobile_scanner: ^7.0.1
+  noise_meter: ^5.0.2
   path: ^1.9.1
   path_provider: ^2.1.5
   permission_handler: ^12.0.1


### PR DESCRIPTION
## Summary
- add `noise_meter` dependency
- implement `BlowAlarmScreen` for microphone blowing challenge
- handle new `AlarmScreenType.blow`
- include option in settings and show when alarm rings

## Testing
- `flutter pub get`
- `dart format -o none lib/screens/home.dart lib/screens/blow_alarm_screen.dart`
- `flutter analyze`


------
https://chatgpt.com/codex/tasks/task_e_686d8e55fcd883248c11f007c6b70cc7