### PR TITLE
Fix GradientSlider callback timing

### DIFF
--- a/lib/widgets/gradient_slider.dart
+++ b/lib/widgets/gradient_slider.dart
@@ -60,8 +60,9 @@ class _GradientSliderState extends State<GradientSlider> {
             final newValue =
                 widget.min + newProgress * (widget.max - widget.min);
             setState(() => _value = newValue);
-            widget.onChanged(_value);
           },
+          onPanEnd: (_) => widget.onChanged(_value),
+          onPanCancel: () => widget.onChanged(_value),
           child: SizedBox(
             height: 48,
             child: Stack(


### PR DESCRIPTION
## Summary
- only invoke `onChanged` once the user finishes sliding in `GradientSlider`

## Testing
- `dart format lib/widgets/gradient_slider.dart --output=none`
- `dart analyze`

------
https://chatgpt.com/codex/tasks/task_e_686c95845138832485f75b96e45c7a45