### PR TITLE
Refactor text styles

### DIFF
--- a/lib/screens/add_alarm_screen.dart
+++ b/lib/screens/add_alarm_screen.dart
@@ -3,6 +3,7 @@ import 'package:awake/models/alarm_model.dart';
 import 'package:awake/services/alarm_cubit.dart';
 import 'package:awake/services/settings_cubit.dart';
 import 'package:awake/theme/app_colors.dart';
+import 'package:awake/theme/app_text_styles.dart';
 import 'package:awake/widgets/add_button.dart';
 import 'package:awake/widgets/time_picker.dart';
 import 'package:flutter/material.dart';
@@ -150,8 +151,7 @@ class _AddAlarmScreenState extends State<AddAlarmScreen> {
             ),
             icon: Text(
               dayLabels[i],
-              style: TextStyle(
-                fontFamily: "Poppins",
+              style: AppTextStyles.caption(context).copyWith(
                 color:
                     _selectedDays.contains(i + 1)
                         ? Colors.white
@@ -204,16 +204,7 @@ class _AddAlarmScreenState extends State<AddAlarmScreen> {
                   ],
           centerTitle: true,
           title: Text(widget.alarmModel == null ? 'Add Alarm' : 'Edit Alarm'),
-          titleTextStyle: TextStyle(
-            color:
-                isDark
-                    ? AppColors.darkBackgroundText
-                    : AppColors.lightBackgroundText,
-            fontFamily: 'Poppins',
-            fontSize: 18,
-            fontWeight: FontWeight.w500,
-            letterSpacing: 0.03,
-          ),
+          titleTextStyle: AppTextStyles.heading(context),
         ),
         body: DecoratedBox(
           decoration: BoxDecoration(

--- a/lib/screens/alarm_ringing_screen.dart
+++ b/lib/screens/alarm_ringing_screen.dart
@@ -2,6 +2,7 @@ import 'package:alarm/alarm.dart';
 import 'package:awake/extensions/context_extensions.dart';
 import 'package:awake/services/alarm_cubit.dart';
 import 'package:awake/theme/app_colors.dart';
+import 'package:awake/theme/app_text_styles.dart';
 import 'package:awake/widgets/snooze_button.dart';
 import 'package:awake/widgets/stop_alarm.dart';
 import 'package:flutter/material.dart';
@@ -37,14 +38,7 @@ class AlarmRingingScreen extends StatelessWidget {
                 const SizedBox(height: 20),
                 Text(
                   alarmSettings.notificationSettings.body,
-                  style: TextStyle(
-                    color:
-                        isDark
-                            ? AppColors.darkBackgroundText
-                            : AppColors.lightBackgroundText,
-                    fontSize: 24,
-                    fontFamily: 'Poppins',
-                  ),
+                  style: AppTextStyles.large(context),
                 ),
                 const Spacer(),
                 GestureDetector(

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -17,6 +17,7 @@ import 'package:awake/services/alarm_cubit.dart';
 import 'package:awake/services/alarm_permissions.dart';
 import 'package:awake/services/settings_cubit.dart';
 import 'package:awake/theme/app_colors.dart';
+import 'package:awake/theme/app_text_styles.dart';
 import 'package:awake/widgets/add_button.dart';
 import 'package:awake/widgets/alarm_tile.dart';
 import 'package:awake/widgets/clock.dart';
@@ -218,16 +219,7 @@ class _HomeState extends State<Home> {
                         return Center(
                           child: Text(
                             "No Alarms Added Yet",
-                            style: TextStyle(
-                              color:
-                                  isDark
-                                      ? AppColors.darkBackgroundText
-                                      : AppColors.lightBackgroundText,
-                              fontFamily: 'Poppins',
-                              fontSize: 18,
-                              fontWeight: FontWeight.w500,
-                              letterSpacing: 0.03,
-                            ),
+                            style: AppTextStyles.heading(context),
                           ),
                         );
                       } else {
@@ -242,16 +234,7 @@ class _HomeState extends State<Home> {
                                 const SizedBox(width: 15),
                                 Text(
                                   "Alarms",
-                                  style: TextStyle(
-                                    color:
-                                        isDark
-                                            ? AppColors.darkBackgroundText
-                                            : AppColors.lightBackgroundText,
-                                    fontFamily: 'Poppins',
-                                    fontSize: 18,
-                                    fontWeight: FontWeight.w500,
-                                    letterSpacing: 0.03,
-                                  ),
+                                  style: AppTextStyles.heading(context),
                                 ),
                                 const Spacer(),
                                 IconButton(

--- a/lib/screens/math_alarm_screen.dart
+++ b/lib/screens/math_alarm_screen.dart
@@ -5,6 +5,7 @@ import 'package:alarm/alarm.dart';
 import 'package:awake/extensions/context_extensions.dart';
 import 'package:awake/services/alarm_cubit.dart';
 import 'package:awake/theme/app_colors.dart';
+import 'package:awake/theme/app_text_styles.dart';
 import 'package:awake/widgets/stop_alarm.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -128,14 +129,7 @@ class _MathAlarmScreenState extends State<MathAlarmScreen> {
                 const Spacer(),
                 Text(
                   widget.alarmSettings.notificationSettings.body,
-                  style: TextStyle(
-                    color:
-                        isDark
-                            ? AppColors.darkBackgroundText
-                            : AppColors.lightBackgroundText,
-                    fontSize: 24,
-                    fontFamily: 'Poppins',
-                  ),
+                  style: AppTextStyles.large(context),
                 ),
                 const SizedBox(height: 20),
                 Row(
@@ -143,14 +137,7 @@ class _MathAlarmScreenState extends State<MathAlarmScreen> {
                   children: [
                     Text(
                       'Solve: $_a $symbol $_b = ',
-                      style: TextStyle(
-                        color:
-                            isDark
-                                ? AppColors.darkBackgroundText
-                                : AppColors.lightBackgroundText,
-                        fontSize: 24,
-                        fontFamily: 'Poppins',
-                      ),
+                      style: AppTextStyles.large(context),
                     ),
                     const SizedBox(width: 5),
                     Container(
@@ -168,13 +155,7 @@ class _MathAlarmScreenState extends State<MathAlarmScreen> {
                       ),
                       child: Text(
                         _input.isEmpty ? '?' : _input,
-                        style: TextStyle(
-                          color:
-                              isDark
-                                  ? AppColors.darkBackgroundText
-                                  : AppColors.lightBackgroundText,
-                          fontSize: 24,
-                        ),
+                        style: AppTextStyles.large(context),
                       ),
                     ),
                   ],
@@ -231,7 +212,7 @@ class _NumberPad extends StatelessWidget {
             },
             icon: Text(
               label == 'DEL' ? '⌫' : label,
-              style: TextStyle(fontSize: 24, color: textColor),
+              style: AppTextStyles.large(context).copyWith(color: textColor),
             ),
           ),
         ),

--- a/lib/screens/qr_alarm_screen.dart
+++ b/lib/screens/qr_alarm_screen.dart
@@ -5,6 +5,7 @@ import 'package:awake/constants.dart';
 import 'package:awake/extensions/context_extensions.dart';
 import 'package:awake/services/alarm_cubit.dart';
 import 'package:awake/theme/app_colors.dart';
+import 'package:awake/theme/app_text_styles.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
@@ -79,14 +80,7 @@ class _QrAlarmScreenState extends State<QrAlarmScreen> {
               const Spacer(),
               Text(
                 widget.alarmSettings.notificationSettings.body,
-                style: TextStyle(
-                  color:
-                      isDark
-                          ? AppColors.darkBackgroundText
-                          : AppColors.lightBackgroundText,
-                  fontSize: 24,
-                  fontFamily: 'Poppins',
-                ),
+                style: AppTextStyles.large(context),
               ),
               const SizedBox(height: 20),
               Expanded(
@@ -97,17 +91,7 @@ class _QrAlarmScreenState extends State<QrAlarmScreen> {
                 ),
               ),
               const SizedBox(height: 20),
-              Text(
-                'Scan the QR Code',
-                style: TextStyle(
-                  color:
-                      isDark
-                          ? AppColors.darkBackgroundText
-                          : AppColors.lightBackgroundText,
-                  fontSize: 24,
-                  fontFamily: 'Poppins',
-                ),
-              ),
+              Text('Scan the QR Code', style: AppTextStyles.large(context)),
               const Spacer(),
             ],
           ),

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -7,6 +7,7 @@ import 'package:awake/services/alarm_permissions.dart';
 import 'package:awake/services/custom_sounds_cubit.dart';
 import 'package:awake/services/settings_cubit.dart';
 import 'package:awake/theme/app_colors.dart';
+import 'package:awake/theme/app_text_styles.dart';
 import 'package:awake/widgets/gradient_slider.dart';
 import 'package:awake/widgets/gradient_switch.dart';
 import 'package:awake/widgets/settings_tile.dart';
@@ -74,16 +75,7 @@ class SettingsScreen extends StatelessWidget {
         ),
         centerTitle: true,
         title: const Text('Settings'),
-        titleTextStyle: TextStyle(
-          color:
-              isDark
-                  ? AppColors.darkBackgroundText
-                  : AppColors.lightBackgroundText,
-          fontFamily: 'Poppins',
-          fontSize: 18,
-          fontWeight: FontWeight.w500,
-          letterSpacing: 0.03,
-        ),
+        titleTextStyle: AppTextStyles.heading(context),
       ),
       body: DecoratedBox(
         decoration: BoxDecoration(
@@ -119,7 +111,9 @@ class SettingsScreen extends StatelessWidget {
                     children: [
                       Text(
                         '24-Hour Format',
-                        style: TextStyle(color: color, fontFamily: 'Poppins'),
+                        style: AppTextStyles.body(
+                          context,
+                        ).copyWith(color: color),
                       ),
                       const Spacer(),
                       GradientSwitch(
@@ -145,7 +139,9 @@ class SettingsScreen extends StatelessWidget {
                     children: [
                       Text(
                         'Vibration',
-                        style: TextStyle(color: color, fontFamily: 'Poppins'),
+                        style: AppTextStyles.body(
+                          context,
+                        ).copyWith(color: color),
                       ),
                       const Spacer(),
                       GradientSwitch(
@@ -176,7 +172,9 @@ class SettingsScreen extends StatelessWidget {
                     children: [
                       Text(
                         'Gradual Fade In',
-                        style: TextStyle(color: color, fontFamily: 'Poppins'),
+                        style: AppTextStyles.body(
+                          context,
+                        ).copyWith(color: color),
                       ),
                       const Spacer(),
                       GradientSwitch(
@@ -200,7 +198,9 @@ class SettingsScreen extends StatelessWidget {
                     children: [
                       Text(
                         'Alarm Screen',
-                        style: TextStyle(color: color, fontFamily: 'Poppins'),
+                        style: AppTextStyles.body(
+                          context,
+                        ).copyWith(color: color),
                       ),
                       const SizedBox(width: 20),
                       Expanded(
@@ -272,7 +272,9 @@ class SettingsScreen extends StatelessWidget {
                       children: [
                         Text(
                           'Download QR Code',
-                          style: TextStyle(color: color, fontFamily: 'Poppins'),
+                          style: AppTextStyles.body(
+                            context,
+                          ).copyWith(color: color),
                         ),
                       ],
                     ),
@@ -324,10 +326,9 @@ class SettingsScreen extends StatelessWidget {
                         children: [
                           Text(
                             'Alarm Sound',
-                            style: TextStyle(
-                              color: color,
-                              fontFamily: 'Poppins',
-                            ),
+                            style: AppTextStyles.body(
+                              context,
+                            ).copyWith(color: color),
                           ),
                           const SizedBox(width: 20),
                           Expanded(
@@ -378,10 +379,9 @@ class SettingsScreen extends StatelessWidget {
                             children: [
                               Text(
                                 'Clear Custom Sounds',
-                                style: TextStyle(
-                                  color: color,
-                                  fontFamily: 'Poppins',
-                                ),
+                                style: AppTextStyles.body(
+                                  context,
+                                ).copyWith(color: color),
                               ),
                             ],
                           ),

--- a/lib/screens/shake_alarm_screen.dart
+++ b/lib/screens/shake_alarm_screen.dart
@@ -5,6 +5,7 @@ import 'package:alarm/alarm.dart';
 import 'package:awake/extensions/context_extensions.dart';
 import 'package:awake/services/alarm_cubit.dart';
 import 'package:awake/theme/app_colors.dart';
+import 'package:awake/theme/app_text_styles.dart';
 import 'package:awake/widgets/gradient_linear_progress_indicator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -87,38 +88,14 @@ class _ShakeAlarmScreenState extends State<ShakeAlarmScreen> {
                 const SizedBox(height: 20),
                 Text(
                   widget.alarmSettings.notificationSettings.body,
-                  style: TextStyle(
-                    color:
-                        isDark
-                            ? AppColors.darkBackgroundText
-                            : AppColors.lightBackgroundText,
-                    fontSize: 24,
-                    fontFamily: 'Poppins',
-                  ),
+                  style: AppTextStyles.large(context),
                 ),
                 const SizedBox(height: 20),
-                Text(
-                  'Shake the phone!',
-                  style: TextStyle(
-                    color:
-                        isDark
-                            ? AppColors.darkBackgroundText
-                            : AppColors.lightBackgroundText,
-                    fontSize: 24,
-                    fontFamily: 'Poppins',
-                  ),
-                ),
+                Text('Shake the phone!', style: AppTextStyles.large(context)),
                 const SizedBox(height: 20),
                 Text(
                   'Shakes: $_shakeCount / $_requiredShakes',
-                  style: TextStyle(
-                    color:
-                        isDark
-                            ? AppColors.darkBackgroundText
-                            : AppColors.lightBackgroundText,
-                    fontSize: 24,
-                    fontFamily: 'Poppins',
-                  ),
+                  style: AppTextStyles.large(context),
                 ),
                 const SizedBox(height: 20),
                 Padding(

--- a/lib/screens/tap_alarm_screen.dart
+++ b/lib/screens/tap_alarm_screen.dart
@@ -2,6 +2,7 @@ import 'package:alarm/alarm.dart';
 import 'package:awake/extensions/context_extensions.dart';
 import 'package:awake/services/alarm_cubit.dart';
 import 'package:awake/theme/app_colors.dart';
+import 'package:awake/theme/app_text_styles.dart';
 import 'package:awake/widgets/gradient_linear_progress_indicator.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -54,38 +55,14 @@ class _TapAlarmScreenState extends State<TapAlarmScreen> {
                 const Spacer(),
                 Text(
                   widget.alarmSettings.notificationSettings.body,
-                  style: TextStyle(
-                    color:
-                        isDark
-                            ? AppColors.darkBackgroundText
-                            : AppColors.lightBackgroundText,
-                    fontSize: 24,
-                    fontFamily: 'Poppins',
-                  ),
+                  style: AppTextStyles.large(context),
                 ),
                 const SizedBox(height: 20),
-                Text(
-                  'Tap the screen!',
-                  style: TextStyle(
-                    color:
-                        isDark
-                            ? AppColors.darkBackgroundText
-                            : AppColors.lightBackgroundText,
-                    fontSize: 24,
-                    fontFamily: 'Poppins',
-                  ),
-                ),
+                Text('Tap the screen!', style: AppTextStyles.large(context)),
                 const SizedBox(height: 20),
                 Text(
                   'Taps: $_tapCount / $_requiredTaps',
-                  style: TextStyle(
-                    color:
-                        isDark
-                            ? AppColors.darkBackgroundText
-                            : AppColors.lightBackgroundText,
-                    fontSize: 24,
-                    fontFamily: 'Poppins',
-                  ),
+                  style: AppTextStyles.large(context),
                 ),
                 const SizedBox(height: 20),
                 Padding(

--- a/lib/theme/app_text_styles.dart
+++ b/lib/theme/app_text_styles.dart
@@ -1,0 +1,33 @@
+import 'dart:ui';
+
+import 'package:awake/extensions/context_extensions.dart';
+import 'package:awake/theme/app_colors.dart';
+import 'package:flutter/material.dart';
+
+class AppTextStyles {
+  AppTextStyles._();
+
+  static TextStyle body(BuildContext context) => TextStyle(
+    color:
+        context.isDarkMode
+            ? AppColors.darkBackgroundText
+            : AppColors.lightBackgroundText,
+    fontFamily: 'Poppins',
+  );
+
+  static TextStyle heading(BuildContext context) => body(
+    context,
+  ).copyWith(fontSize: 18, fontWeight: FontWeight.w500, letterSpacing: 0.03);
+
+  static TextStyle bigTime(BuildContext context) => body(context).copyWith(
+    fontSize: 34,
+    fontWeight: FontWeight.w500,
+    fontFeatures: const [FontFeature.tabularFigures()],
+  );
+
+  static TextStyle large(BuildContext context) =>
+      body(context).copyWith(fontSize: 24);
+
+  static TextStyle caption(BuildContext context) =>
+      body(context).copyWith(fontSize: 12, letterSpacing: 0.03);
+}

--- a/lib/theme/app_text_styles.dart
+++ b/lib/theme/app_text_styles.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:awake/extensions/context_extensions.dart';
 import 'package:awake/theme/app_colors.dart';
 import 'package:flutter/material.dart';

--- a/lib/widgets/alarm_tile.dart
+++ b/lib/widgets/alarm_tile.dart
@@ -2,6 +2,7 @@ import 'package:awake/models/alarm_model.dart';
 import 'package:awake/screens/add_alarm_screen.dart';
 import 'package:awake/services/settings_cubit.dart';
 import 'package:awake/theme/app_colors.dart';
+import 'package:awake/theme/app_text_styles.dart';
 import 'package:awake/widgets/gradient_switch.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -62,11 +63,7 @@ class _AlarmTileState extends State<AlarmTile> {
 
     return Text.rich(
       TextSpan(children: textSpans),
-      style: const TextStyle(
-        fontFamily: 'Poppins',
-        fontSize: 12,
-        letterSpacing: 0.03,
-      ),
+      style: AppTextStyles.caption(context),
     );
   }
 
@@ -159,18 +156,7 @@ class _AlarmTileState extends State<AlarmTile> {
                               widget.alarmModel.timeOfDay,
                               alwaysUse24HourFormat: use24h,
                             ),
-                            style: TextStyle(
-                              color:
-                                  isDark
-                                      ? AppColors.darkBackgroundText
-                                      : AppColors.lightBackgroundText,
-                              fontFamily: 'Poppins',
-                              fontSize: 34,
-                              fontWeight: FontWeight.w500,
-                              fontFeatures: const [
-                                FontFeature.tabularFigures(),
-                              ],
-                            ),
+                            style: AppTextStyles.bigTime(context),
                           ),
                         ),
                         _repeatDayText(isDark),

--- a/lib/widgets/snooze_button.dart
+++ b/lib/widgets/snooze_button.dart
@@ -1,6 +1,6 @@
+import 'package:awake/theme/app_text_styles.dart';
 import 'package:awake/widgets/add_button.dart';
 import 'package:awake/widgets/minus_button.dart';
-import 'package:awake/theme/app_text_styles.dart';
 import 'package:flutter/material.dart';
 
 class SnoozeButton extends StatefulWidget {

--- a/lib/widgets/snooze_button.dart
+++ b/lib/widgets/snooze_button.dart
@@ -1,5 +1,6 @@
 import 'package:awake/widgets/add_button.dart';
 import 'package:awake/widgets/minus_button.dart';
+import 'package:awake/theme/app_text_styles.dart';
 import 'package:flutter/material.dart';
 
 class SnoozeButton extends StatefulWidget {
@@ -55,7 +56,7 @@ class _SnoozeButtonState extends State<SnoozeButton> {
                 ),
                 child: Text(
                   'Snooze: $snoozeMinutes min',
-                  style: TextStyle(
+                  style: AppTextStyles.body(context).copyWith(
                     fontSize: 16,
                     fontWeight: FontWeight.w600,
                     color: isDark ? Colors.white : Colors.black87,

--- a/lib/widgets/theme_list_tile.dart
+++ b/lib/widgets/theme_list_tile.dart
@@ -1,5 +1,6 @@
 import 'package:awake/extensions/context_extensions.dart';
 import 'package:awake/theme/app_colors.dart';
+import 'package:awake/theme/app_text_styles.dart';
 import 'package:awake/widgets/settings_tile.dart';
 import 'package:flutter/material.dart';
 
@@ -40,7 +41,7 @@ class ThemeListTile extends StatelessWidget {
       onTap: () => onChanged(_nextMode(mode)),
       child: Row(
         children: [
-          Text('Theme', style: TextStyle(color: color, fontFamily: 'Poppins')),
+          Text('Theme', style: AppTextStyles.body(context)),
           const Spacer(),
           Icon(_iconForMode(mode), color: color),
         ],


### PR DESCRIPTION
## Summary
- centralize styles in `AppTextStyles`
- reuse shared styles across widgets and screens

## Testing
- `dart format lib/theme/app_text_styles.dart lib/widgets/theme_list_tile.dart lib/widgets/snooze_button.dart lib/widgets/alarm_tile.dart lib/screens/add_alarm_screen.dart lib/screens/shake_alarm_screen.dart lib/screens/alarm_ringing_screen.dart lib/screens/home.dart lib/screens/math_alarm_screen.dart lib/screens/tap_alarm_screen.dart lib/screens/qr_alarm_screen.dart lib/screens/settings_screen.dart`

------
https://chatgpt.com/codex/tasks/task_e_686dfd575920832488f53aeca183ae88