### PR TITLE
Add blow to stop alarm screen

### DIFF
--- a/lib/models/alarm_screen_type.dart
+++ b/lib/models/alarm_screen_type.dart
@@ -1,1 +1,1 @@
-enum AlarmScreenType { ringing, math, shake, qr, tap }
+enum AlarmScreenType { ringing, math, shake, qr, tap, blow }

--- a/lib/screens/blow_alarm_screen.dart
+++ b/lib/screens/blow_alarm_screen.dart
@@ -1,0 +1,146 @@
+import 'dart:async';
+
+import 'package:alarm/alarm.dart';
+import 'package:awake/extensions/context_extensions.dart';
+import 'package:awake/services/alarm_cubit.dart';
+import 'package:awake/theme/app_colors.dart';
+import 'package:awake/widgets/gradient_linear_progress_indicator.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:record/record.dart';
+
+class BlowAlarmScreen extends StatefulWidget {
+  final AlarmSettings alarmSettings;
+  const BlowAlarmScreen({super.key, required this.alarmSettings});
+
+  @override
+  State<BlowAlarmScreen> createState() => _BlowAlarmScreenState();
+}
+
+class _BlowAlarmScreenState extends State<BlowAlarmScreen> {
+  final AudioRecorder _recorder = AudioRecorder();
+  StreamSubscription<Amplitude>? _subscription;
+  int _blowCount = 0;
+  static const int _requiredBlows = 3;
+  static const double _thresholdDb = -10.0;
+  DateTime? _lastBlow;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(_start());
+  }
+
+  Future<void> _start() async {
+    if (await _recorder.hasPermission()) {
+      await _recorder.startStream(const RecordConfig());
+      _subscription = _recorder
+          .onAmplitudeChanged(const Duration(milliseconds: 100))
+          .listen(_onAmplitude);
+    }
+  }
+
+  Future<void> _onAmplitude(Amplitude amplitude) async {
+    if (amplitude.current > _thresholdDb) {
+      final now = DateTime.now();
+      if (_lastBlow == null ||
+          now.difference(_lastBlow!) > const Duration(milliseconds: 500)) {
+        _lastBlow = now;
+        setState(() => _blowCount++);
+        if (_blowCount >= _requiredBlows) {
+          await _subscription?.cancel();
+          await _recorder.stop();
+          if (!mounted) return;
+          await context.read<AlarmCubit>().stopAlarm(widget.alarmSettings.id);
+          if (mounted) {
+            Navigator.pop(context);
+          }
+        }
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    unawaited(_subscription?.cancel());
+    unawaited(_recorder.stop());
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool isDark = context.isDarkMode;
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        body: DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: isDark
+                  ? [AppColors.darkScaffold1, AppColors.darkScaffold2]
+                  : [AppColors.lightScaffold1, AppColors.lightScaffold2],
+            ),
+          ),
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Spacer(),
+                Icon(
+                  Icons.mic,
+                  size: 120,
+                  color: isDark
+                      ? AppColors.darkBackgroundText
+                      : AppColors.lightBackgroundText,
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  widget.alarmSettings.notificationSettings.body,
+                  style: TextStyle(
+                    color: isDark
+                        ? AppColors.darkBackgroundText
+                        : AppColors.lightBackgroundText,
+                    fontSize: 24,
+                    fontFamily: 'Poppins',
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  'Blow on the microphone!',
+                  style: TextStyle(
+                    color: isDark
+                        ? AppColors.darkBackgroundText
+                        : AppColors.lightBackgroundText,
+                    fontSize: 24,
+                    fontFamily: 'Poppins',
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Text(
+                  'Blows: $_blowCount / $_requiredBlows',
+                  style: TextStyle(
+                    color: isDark
+                        ? AppColors.darkBackgroundText
+                        : AppColors.lightBackgroundText,
+                    fontSize: 24,
+                    fontFamily: 'Poppins',
+                  ),
+                ),
+                const SizedBox(height: 20),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 40),
+                  child: GradientLinearProgressIndicator(
+                    value: _blowCount / _requiredBlows,
+                  ),
+                ),
+                const Spacer(),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -8,6 +8,7 @@ import 'package:awake/models/alarm_model.dart';
 import 'package:awake/models/alarm_screen_type.dart';
 import 'package:awake/screens/add_alarm_screen.dart';
 import 'package:awake/screens/alarm_ringing_screen.dart';
+import 'package:awake/screens/blow_alarm_screen.dart';
 import 'package:awake/screens/math_alarm_screen.dart';
 import 'package:awake/screens/qr_alarm_screen.dart';
 import 'package:awake/screens/settings_screen.dart';
@@ -68,6 +69,8 @@ class _HomeState extends State<Home> {
       screen = QrAlarmScreen(alarmSettings: alarms.alarms.first);
     } else if (screenType == AlarmScreenType.tap) {
       screen = TapAlarmScreen(alarmSettings: alarms.alarms.first);
+    } else if (screenType == AlarmScreenType.blow) {
+      screen = BlowAlarmScreen(alarmSettings: alarms.alarms.first);
     }
     await Navigator.push(
       context,

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -230,6 +230,10 @@ class SettingsScreen extends StatelessWidget {
                               child: Text('Tap Challenge'),
                             ),
                             DropdownMenuItem(
+                              value: AlarmScreenType.blow,
+                              child: Text('Blow to Stop'),
+                            ),
+                            DropdownMenuItem(
                               value: AlarmScreenType.qr,
                               child: Text('QR Code Scan'),
                             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "10.2.0"
+  fixnum:
+    dependency: transitive
+    description:
+      name: fixnum
+      sha256: b6dc7065e46c974bc7c5f143080a6764ec7a4be6da1285ececdc37be96de53be
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -424,6 +432,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.5"
+  record:
+    dependency: "direct main"
+    description:
+      name: record
+      sha256: daeb3f9b3fea9797094433fe6e49a879d8e4ca4207740bc6dc7e4a58764f0817
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.0.0"
+  record_android:
+    dependency: transitive
+    description:
+      name: record_android
+      sha256: "97d7122455f30de89a01c6c244c839085be6b12abca251fc0e78f67fed73628b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.3"
+  record_ios:
+    dependency: transitive
+    description:
+      name: record_ios
+      sha256: "73706ebbece6150654c9d6f57897cf9b622c581148304132ba85dba15df0fdfb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  record_linux:
+    dependency: transitive
+    description:
+      name: record_linux
+      sha256: "0626678a092c75ce6af1e32fe7fd1dea709b92d308bc8e3b6d6348e2430beb95"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
+  record_macos:
+    dependency: transitive
+    description:
+      name: record_macos
+      sha256: "02240833fde16c33fcf2c589f3e08d4394b704761b4a3bb609d872ff3043fbbd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
+  record_platform_interface:
+    dependency: transitive
+    description:
+      name: record_platform_interface
+      sha256: c1ad38f51e4af88a085b3e792a22c685cb3e7c23fc37aa7ce44c4cf18f25fe89
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  record_web:
+    dependency: transitive
+    description:
+      name: record_web
+      sha256: a12856d0b3dd03d336b4b10d7520a8b3e21649a06a8f95815318feaa8f07adbb
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.9"
+  record_windows:
+    dependency: transitive
+    description:
+      name: record_windows
+      sha256: "85a22fc97f6d73ecd67c8ba5f2f472b74ef1d906f795b7970f771a0914167e99"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.6"
   rxdart:
     dependency: transitive
     description:
@@ -517,6 +589,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   sqflite:
     dependency: "direct main"
     description:
@@ -613,6 +693,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  uuid:
+    dependency: transitive
+    description:
+      name: uuid
+      sha256: a5be9ef6618a7ac1e964353ef476418026db906c4facdedaa299b7a2e71690ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.5.1"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   path: ^1.9.1
   path_provider: ^2.1.5
   permission_handler: ^12.0.1
+  record: ^6.0.0
   sensors_plus: ^6.1.1
   shared_preferences: ^2.5.3
   sqflite: ^2.4.2


### PR DESCRIPTION
## Summary
- add `record` dependency for microphone access
- add new `BlowAlarmScreen` for blowing on the mic to dismiss alarms
- integrate new screen with settings and alarm routing
- update enum `AlarmScreenType`

## Testing
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_686dfd140b7883248b35d90fc8873c9d