### PR TITLE
Enable auto-start permission

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -59,9 +59,9 @@ class _HomeState extends State<Home> {
   void initState() {
     super.initState();
     unawaited(
-      AlarmPermissions.checkNotificationPermission().then(
-        (_) => AlarmPermissions.checkAndroidScheduleExactAlarmPermission(),
-      ),
+      AlarmPermissions.checkNotificationPermission()
+          .then((_) => AlarmPermissions.checkAndroidScheduleExactAlarmPermission())
+          .then((_) => AlarmPermissions.checkAutoStartPermission()),
     );
     _ringSubscription = Alarm.ringing.listen(_ringingAlarmsChanged);
   }

--- a/lib/services/alarm_permissions.dart
+++ b/lib/services/alarm_permissions.dart
@@ -1,4 +1,5 @@
 import 'package:alarm/alarm.dart';
+import 'package:auto_start_flutter/auto_start_flutter.dart';
 import 'package:permission_handler/permission_handler.dart';
 
 class AlarmPermissions {
@@ -23,5 +24,12 @@ class AlarmPermissions {
       status = await Permission.camera.request();
     }
     return status.isGranted;
+  }
+
+  static Future<void> checkAutoStartPermission() async {
+    final isAvailable = await isAutoStartAvailable;
+    if (isAvailable ?? false) {
+      await getAutoStartPermission();
+    }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -25,6 +25,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
+  auto_start_flutter:
+    dependency: "direct main"
+    description:
+      name: auto_start_flutter
+      sha256: "1373507dfa31433b92fe95e4307e3061ba1ed2abbe7bc13b742d038a12d697a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4"
   bloc:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
 
 dependencies:
   alarm: ^5.1.4
+  auto_start_flutter: ^0.1.4
   device_preview_plus: ^2.4.4
   file_picker: ^10.2.0
   flutter:


### PR DESCRIPTION
## Summary
- add `auto_start_flutter` dependency
- request auto-start permission in `AlarmPermissions`
- request it from home screen during initialization

## Testing
- `flutter pub get`
- `flutter analyze`

------
https://chatgpt.com/codex/tasks/task_e_6872a8e184e08324b63fa0d0655e4b29