### PR TITLE
Add basic unit tests

### DIFF
--- a/test/alarm_db_entry_test.dart
+++ b/test/alarm_db_entry_test.dart
@@ -1,0 +1,31 @@
+import 'package:awake/models/alarm_db_entry.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('toMap and fromMap should be inverses', () {
+    final entry = AlarmDbEntry(
+      time: const TimeOfDay(hour: 7, minute: 30),
+      days: const [DateTime.monday, DateTime.friday],
+      enabled: false,
+      body: 'Morning alarm',
+    );
+
+    final map = entry.toMap();
+    final restored = AlarmDbEntry.fromMap(map);
+
+    expect(restored.time, entry.time);
+    expect(restored.days, entry.days);
+    expect(restored.enabled, entry.enabled);
+    expect(restored.body, entry.body);
+  });
+
+  test('fromMap handles missing fields', () {
+    final restored = AlarmDbEntry.fromMap({'time': '6:15'});
+
+    expect(restored.time, const TimeOfDay(hour: 6, minute: 15));
+    expect(restored.days, isEmpty);
+    expect(restored.enabled, isTrue);
+    expect(restored.body, '');
+  });
+}

--- a/test/context_extensions_test.dart
+++ b/test/context_extensions_test.dart
@@ -1,0 +1,42 @@
+import 'package:awake/extensions/context_extensions.dart';
+import 'package:awake/l10n/generated/app_localizations.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('isDarkMode detects theme', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: ThemeData.light(),
+        darkTheme: ThemeData.dark(),
+        themeMode: ThemeMode.dark,
+        home: Builder(
+          builder: (context) {
+            final isDark = context.isDarkMode;
+            return Text('$isDark', textDirection: TextDirection.ltr);
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('true'), findsOneWidget);
+  });
+
+  testWidgets('localization getter returns translations', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: const [Locale('en')],
+        locale: const Locale('en'),
+        home: Builder(
+          builder: (context) {
+            final text = context.localization.appTitle;
+            return Text(text, textDirection: TextDirection.ltr);
+          },
+        ),
+      ),
+    );
+
+    expect(find.text('Awake- The Alarm Clock'), findsOneWidget);
+  });
+}

--- a/test/shared_prefs_with_cache_test.dart
+++ b/test/shared_prefs_with_cache_test.dart
@@ -1,0 +1,27 @@
+import 'package:awake/services/shared_prefs_with_cache.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart' as sp;
+
+void main() {
+  setUp(() async {
+    sp.SharedPreferences.setMockInitialValues(<String, Object>{});
+    await SharedPreferencesWithCache.initialize();
+  });
+
+  test('get returns value set via setters', () async {
+    await SharedPreferencesWithCache.instance.setInt('int', 1);
+    await SharedPreferencesWithCache.instance.setDouble('double', 2.5);
+    await SharedPreferencesWithCache.instance.setString('string', 'hi');
+
+    expect(SharedPreferencesWithCache.instance.get<int>('int'), 1);
+    expect(SharedPreferencesWithCache.instance.get<double>('double'), 2.5);
+    expect(SharedPreferencesWithCache.instance.get<String>('string'), 'hi');
+  });
+
+  test('values are cached', () async {
+    await SharedPreferencesWithCache.instance.setInt('cached', 1);
+    final prefs = await sp.SharedPreferences.getInstance();
+    await prefs.setInt('cached', 2);
+    expect(SharedPreferencesWithCache.instance.get<int>('cached'), 1);
+  });
+}


### PR DESCRIPTION
## Summary
- add Flutter unit tests for the alarm database model, shared prefs wrapper, and context extensions

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68744752953c8324b2fc748537d47019