### PR TITLE
Ensure alarm screen shows on lock

### DIFF
--- a/android/app/src/main/kotlin/com/adeeteya/awake/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/adeeteya/awake/MainActivity.kt
@@ -1,5 +1,15 @@
 package com.adeeteya.awake
 
+import android.os.Build
+import android.os.Bundle
 import io.flutter.embedding.android.FlutterActivity
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            setShowWhenLocked(true)
+            setTurnScreenOn(true)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show `MainActivity` when locked by enabling `setShowWhenLocked`

## Testing
- `flutter analyze`
- `flutter test` *(fails: Test directory "test" not found.)*

------
https://chatgpt.com/codex/tasks/task_e_6874be1baa4c83248e16be20425c5063